### PR TITLE
Auto run db migrations when deploying to Heroku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,3 @@
+# .buildpacks contents to auto run rake db:migrate on every deploy:
+https://github.com/heroku/heroku-buildpack-ruby.git
+https://github.com/gunpowderlabs/buildpack-ruby-db-migrate.git


### PR DESCRIPTION
See http://gunpowderlabs.com/blog/automatically-run-migrations-when-deploying-to-heroku/
for the low-down. Should circumvent having to use CircleCI to push to Heroku (this is essentially the same since Heroku won't deploy the develop branch unless CircleCI passes), this is probably easier since GitHub is natively integrated with Heroku.
