### PR TITLE
Amp/quick false is obstructed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Ignore bundler config.
 /.bundle
 /.ruby-version
+/.byebug_history
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -24,11 +24,6 @@ class Piece < ActiveRecord::Base
   end
 
   def is_obstructed?
-    # test for pieces adjacent to current position
-    # Horizontal obstructions
-    # Vertical obstructions
-    # Diagonal Obstructions
-    # Invalid input (none of the above) - doesn't makes
-    # sense: raise an error message
+    false
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -23,7 +23,7 @@ class Piece < ActiveRecord::Base
     x_y_coordinates
   end
 
-  def is_obstructed?
+  def is_obstructed?(x, y)
     false
   end
 end


### PR DESCRIPTION
This is a temporary false placeholder for is_obstructed method so I don't impede progress on other methods. Added .byebug_history to .gitignore. I pulled latest develop moments before changes so this should be a quick and easy merge. ~AMP
