### PR TITLE
Amp/is obstructed

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -92,7 +92,7 @@ class Piece < ActiveRecord::Base
       # vertical move to next square or delta 0
       return false
     elsif delta_x == delta_y && delta_x > 0
-      # SE move, positive X, positive Y diagonal
+      # NE move: positive X, positive Y diagonal
       steps = delta_x - 1
       steps.times do
         state_x += 1
@@ -101,7 +101,7 @@ class Piece < ActiveRecord::Base
       end
       return false
     elsif delta_x == delta_y && delta_x < 0
-      # NW move, negative X negative Y diagonal
+      # SW move: negative X negative Y diagonal
       steps = delta_x.abs - 1
       steps.times do
         state_x -= 1
@@ -110,7 +110,7 @@ class Piece < ActiveRecord::Base
       end
       return false
     elsif delta_x > 0 && delta_y < 0 && delta_x == delta_y.abs
-      # NE move, positive X, negative Y diagonal
+      # SE move: positive X, negative Y diagonal
       steps = delta_x - 1
       steps.times do
         state_x += 1
@@ -119,7 +119,7 @@ class Piece < ActiveRecord::Base
       end
       return false
     elsif delta_x < 0 && delta_y > 0 && delta_x.abs == delta_y
-      # SW move, negative X, positive Y diagonal
+      # NW move: negative X, positive Y diagonal
       steps = delta_y - 1
       steps.times do
         state_x -= 1

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -274,5 +274,10 @@ RSpec.describe Piece, type: :model do
       # also tests single space movement graceful handling in diagonal
       expect(@white_queen.is_obstructed?(1, 1)).to eq false
     end
+    
+    after :all do
+      @game.pieces.delete_all
+      @game.delete
+    end
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -114,14 +114,14 @@ RSpec.describe Piece, type: :model do
       @game = FactoryGirl.create(:game)
       @game.pieces.delete_all
       @white_queen = Queen.create(
-        x_position: 0,
-        y_position: 2,
+        x_position: 2,
+        y_position: 0,
         color: true,
         game_id: @game.id
       )
       @white_knight = Knight.create(
-        x_position: 0,
-        y_position: 1,
+        x_position: 1,
+        y_position: 0,
         color: true,
         game_id: @game.id
       )
@@ -175,7 +175,7 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'will be false when horizontal axis path is clear' do
-      expect(@white_queen.is_obstructed?(0, 5)).to eq false
+      expect(@white_queen.is_obstructed?(5, 0)).to eq false
     end
 
     it 'will be false when horiz axis path clear neg direction' do
@@ -183,11 +183,11 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'will be false when moves to next square in horiz axis' do
-      expect(@black_queen.is_obstructed?(6, 5)).to eq false
+      expect(@black_queen.is_obstructed?(5, 6)).to eq false
     end
 
     it 'will be false with move to next square horiz negative' do
-      expect(@black_queen.is_obstructed?(6, 3)).to eq false
+      expect(@black_queen.is_obstructed?(3, 6)).to eq false
     end
 
     it 'will be true when there is a block in horizontal axis' do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -132,25 +132,37 @@ RSpec.describe Piece, type: :model do
         game_id: @game.id
       )
       @white_bishop = Bishop.create(
-        x_position: 4,
-        y_position: 2,
+        x_position: 2,
+        y_position: 4,
         color: true,
         game_id: @game.id
       )
       @white_rook = Rook.create(
-        x_position: 7,
-        y_position: 2,
+        x_position: 2,
+        y_position: 7,
         color: true,
         game_id: @game.id
       )
       @black_pawn = Pawn.create(
+        x_position: 6,
+        y_position: 4,
+        color: false,
+        game_id: @game.id
+      )
+      @black_queen = Queen.create(
         x_position: 4,
         y_position: 6,
         color: false,
         game_id: @game.id
       )
-      @black_queen = Queen.create(
+      @black_rook = Rook.create(
         x_position: 6,
+        y_position: 6,
+        color: false,
+        game_id: @game.id
+      )
+      @black_bishop = Bishop.create(
+        x_position: 5,
         y_position: 4,
         color: false,
         game_id: @game.id
@@ -158,68 +170,108 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'will raise an Error Message with invalid input' do
-      expect { @white_queen.is_obstructed?(3, 4) }
+      expect { @white_queen.is_obstructed?(4, 3) }
         .to raise_error("Invalid input or invalid move.")
     end
 
     it 'will be false when horizontal axis path is clear' do
-      expect(@white_queen.is_obstructed?(3, 2)).to eq false
-    end
-
-    it 'will be false when horiz axis path clear neg direction' do
-      expect(@black_queen.is_obstructed?(1, 4)).to eq false
-    end
-
-    it 'will be false when moves to next square in horiz axis' do
-      expect(@black_queen.is_obstructed?(7, 4)).to eq false
-    end
-
-    it 'will be true when there is a block in horizontal axis' do
-      expect(@white_queen.is_obstructed?(5, 2)).to eq true
-    end
-
-    it 'will be true when there is a block in vertical axis' do
-      expect(@white_queen.is_obstructed?(0, 0)).to eq true
-    end
-
-    it 'will be true with block in vertical axis, neg direction' do
-      expect(@white_rook.is_obstructed?(3, 2)).to eq true
-    end
-
-    it 'will be false when vertical axis path is clear' do
       expect(@white_queen.is_obstructed?(0, 5)).to eq false
     end
 
-    it 'will be false when vertical axis path clear neg direction' do
-      expect(@black_queen.is_obstructed?(6, 1)).to eq false
+    it 'will be false when horiz axis path clear neg direction' do
+      expect(@black_queen.is_obstructed?(1, 6)).to eq false
     end
 
-    it 'will be false when moves to next square in vert axis' do
-      expect(@white_queen.is_obstructed?(0, 3)).to eq false
+    it 'will be false when moves to next square in horiz axis' do
+      expect(@black_queen.is_obstructed?(6, 5)).to eq false
+    end
+
+    it 'will be false with move to next square horiz negative' do
+      expect(@black_queen.is_obstructed?(6, 3)).to eq false
+    end
+
+    it 'will be true when there is a block in horizontal axis' do
+      expect(@black_queen.is_obstructed?(7, 6)).to eq true
+    end
+
+    it 'will be true with block in horiz axis neg direction' do
+      expect(@white_queen.is_obstructed?(0, 0)).to eq true
+    end
+
+    it 'will be true with block in vertical axis' do
+      expect(@white_queen.is_obstructed?(2, 5)).to eq true
+    end
+
+    it 'will be true with block in vertical axis, neg direction' do
+      expect(@white_rook.is_obstructed?(2, 3)).to eq true
+    end
+
+    it 'will be false when vertical axis path is clear' do
+      expect(@white_queen.is_obstructed?(2, 3)).to eq false
+    end
+
+    it 'will be false when vertical axis path clear neg direction' do
+      expect(@black_queen.is_obstructed?(4, 1)).to eq false
+    end
+
+    it 'will be false with move to next square vertical axis' do
+      expect(@white_queen.is_obstructed?(2, 1)).to eq false
+    end
+
+    it 'will be false with move to next square vert axis negative' do
+      expect(@black_queen.is_obstructed?(4, 5)).to eq false
+    end
+
+    it 'will be false when NE diag path is clear' do
+      expect(@white_queen.is_obstructed?(4, 2)).to eq false
+    end
+
+    it 'will be false when NE diag path clear, piece at endpoint' do
+      expect(@white_queen.is_obstructed?(6, 4)).to eq false
+    end
+
+    it 'will be true when NE diag path has block' do
+      expect(@white_queen.is_obstructed?(7, 5)).to eq true
     end
 
     it 'will be false when SE diag path is clear' do
-      expect(@white_queen.is_obstructed?(2, 4)).to eq false
+      expect(@white_bishop.is_obstructed?(5, 1)).to eq false
     end
 
-    it 'will be true when SW diag path has block, neg direction' do
-      expect(@black_queen.is_obstructed?(3, 7)).to eq true
+    it 'will be false when SE diag path clear, piece at endpoint' do
+      expect(@black_queen.is_obstructed?(6, 4)).to eq false
     end
 
-    it 'will be false when NW diag path is clear, piece at endpoint' do
-      expect(@black_queen.is_obstructed?(4, 2)).to eq false
+    it 'will be true when SE diag path has block, neg direction' do
+      expect(@black_queen.is_obstructed?(7, 3)).to eq true
+    end
+
+    it 'will be false when SW diag path is clear' do
+      expect(@white_bishop.is_obstructed?(0, 2)).to eq false
+    end
+
+    it 'will be false when SW diag path clear, piece at endpoint' do
+      expect(@black_queen.is_obstructed?(2, 4)).to eq false
+    end
+
+    it 'will be true when SW diag path blocked' do
+      expect(@black_queen.is_obstructed?(1, 3)).to eq true
+    end
+
+    it 'will be false when NW diag path is clear' do
+      expect(@white_bishop.is_obstructed?(0, 6)).to eq false
+    end
+
+    it 'will be false when NW diag path clear, piece at endpoint' do
+      expect(@black_bishop.is_obstructed?(2, 7)).to eq false
     end
 
     it 'will be true when NW diag path blocked' do
-      expect(@black_queen.is_obstructed?(3, 1)).to eq true
-    end
-
-    it 'ewill be true when there is a block in the diagonal' do
-      expect(@white_queen.is_obstructed?(2, 0)).to eq true
+      expect(@white_queen.is_obstructed?(0, 2)).to eq true
     end
 
     it 'will be false with clear path if destination contains piece' do
-      # this also tests single space movement graceful handling by diag method
+      # also tests single space movement graceful handling in diagonal
       expect(@white_queen.is_obstructed?(1, 1)).to eq false
     end
   end


### PR DESCRIPTION
Added missing tests to test all vectors of movement, fixed several notes and sets of coordinates resulting from an initial incorrect spatial orientation in initial design of tests (they were off by 90 degrees). Rake passes all extant tests. Base is current with develop branch as of 20151205 23:18 CST.
