### PR TITLE
Jg/turn logic

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -71,7 +71,7 @@ class GamesController < ApplicationController
 
   def merge_player_color_choice_param
     if params[:game][:creator_plays_as_black] == '1'
-      { black_user_id: current_user.id, user_turn: current_user.id }
+      { black_user_id: current_user.id }
     else
       { white_user_id: current_user.id, user_turn: current_user.id }
     end
@@ -85,7 +85,7 @@ class GamesController < ApplicationController
 
   def update_player
     if @game.white_user_id.nil?
-      @game.update_attributes(white_user_id: current_user.id)
+      @game.update_attributes(white_user_id: current_user.id, user_turn: current_user.id)
       @game.set_pieces_white_user_id
     else
       @game.update_attributes(black_user_id: current_user.id)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -23,7 +23,7 @@ class GamesController < ApplicationController
 
   def update
     @game = Game.find(params[:id])
-    if @game.white_user_id.nil? || @game.black_user_id.nil?
+    if @game.player_missing?
       update_player
       if @game.errors.empty?
         redirect_to game_path(@game)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -71,15 +71,15 @@ class GamesController < ApplicationController
 
   def merge_player_color_choice_param
     if params[:game][:creator_plays_as_black] == '1'
-      { black_user_id: current_user.id }
+      { black_user_id: current_user.id, user_turn: current_user.id }
     else
-      { white_user_id: current_user.id }
+      { white_user_id: current_user.id, user_turn: current_user.id }
     end
   end
 
   def game_create_params
     params.require(:game).permit(:game_name, :creator_plays_as_black,
-                                 :white_user_id, :black_user_id)
+                                 :white_user_id, :black_user_id, :user_turn)
       .merge(merge_player_color_choice_param)
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,22 +1,40 @@
 class PiecesController < ApplicationController
   before_action :authenticate_user!
+  before_action :must_be_users_turn, :must_be_users_piece
+  after_action :flash_notice, only: :update
 
   def show
+    if @piece.game.player_missing?
+      flash[:alert] = "Cannot move until both players have joined!"
+      redirect_to game_path(@piece.game)
+    end
     @piece = Piece.find(params[:id])
     @current_game = current_game
   end
 
   def update
+    if @piece.game.player_missing?
+      flash[:alert] = "Cannot move until both players have joined!"
+      redirect_to game_path(@piece.game)
+    end
     @piece = Piece.find(params[:id])
     new_x = params[:x].to_i
     new_y = params[:y].to_i
-    @piece.move_to!(new_x, new_y)
+    if @piece.move_to!(new_x, new_y)
+      @piece.game.finish_turn(@piece.user)
+    end
     redirect_to game_path(@piece.game)
   end
 
   private
 
   helper_method :current_game, :show_piece_td
+
+  def flash_notice
+    if @piece.flash_message.present?
+      flash[:alert] = @piece.flash_message
+    end
+  end
 
   def current_game
     @piece = Piece.find(params[:id])
@@ -57,4 +75,19 @@ class PiecesController < ApplicationController
   def piece_type(piece)
     piece.present? ? piece.piece_type : nil
   end
+
+  def must_be_users_turn
+    if current_user.id != current_game.user_turn
+      flash[:alert] = "Not your turn!"
+      redirect_to game_path(current_game)
+    end
+  end
+
+  def must_be_users_piece
+    if @piece.user.nil? || current_user.id != @piece.user.id
+      flash[:alert] = "Not your piece!"
+      redirect_to game_path(current_game)
+    end
+  end
+
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -15,7 +15,7 @@ class PiecesController < ApplicationController
   def update
     if @piece.game.player_missing?
       flash[:alert] = "Cannot move until both players have joined!"
-      redirect_to game_path(@piece.game)
+      redirect_to game_path(@piece.game) and return
     end
     @piece = Piece.find(params[:id])
     new_x = params[:x].to_i

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -167,7 +167,6 @@ class Game < ActiveRecord::Base
 
   def user_turn_must_be_valid
     return unless (user_turn != white_user_id) && (user_turn != black_user_id)
-    binding.pry
     errors.add(:user_turn, 'Current turn is neither white or black user!')
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -12,6 +12,7 @@ class Game < ActiveRecord::Base
   validate :white_user_id_exists, if: :white_user_id?, on: :update
   validate :black_user_id_exists, if: :black_user_id?, on: :update
   validate :users_must_be_different, on: :update
+  validate :user_turn_must_be_valid, on: :update
   after_create :populate_board!
 
   # This is part of STI ~AMP:
@@ -39,6 +40,27 @@ class Game < ActiveRecord::Base
   def set_pieces_white_user_id
     pieces.where(color: true).each do |curr_piece|
       curr_piece.update_attributes(user_id: white_user_id)
+    end
+  end
+
+  def set_turn_id (player_id)
+    self.user_turn = player_id
+    self.save!
+  end
+
+  def finish_turn(player)
+    if player == black_user
+      set_turn_id(white_user_id)
+    else
+      set_turn_id(black_user_id)
+    end
+  end
+
+  def current_player
+    if self.user_turn == black_user_id
+      return self.black_user
+    else
+      return self.white_user
     end
   end
 
@@ -141,5 +163,11 @@ class Game < ActiveRecord::Base
   def users_must_be_different
     return unless black_user_id == white_user_id
     errors.add(:base, 'White and Black users cannot be the same!')
+  end
+
+  def user_turn_must_be_valid
+    return unless (user_turn != white_user_id) && (user_turn != black_user_id)
+    binding.pry
+    errors.add(:user_turn, 'Current turn is neither white or black user!')
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -44,11 +44,13 @@ class Piece < ActiveRecord::Base
       self.flash_message = "Invalid move: [error to be defined]"
       return false
     end
-    #fail "Invalid move: [error to be defined]" unless valid_move?(x, y)
     if @target.nil?
       update_attributes(:x_position => x, :y_position => y)
     else
-      fail "Invalid move: same color piece" if color == @target.color
+      if color == @target.color
+        self.flash_message =  "Invalid move: same color piece"
+        return false
+      end
       capture(x, y)
     end
     return true

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,6 +5,7 @@
   <div class="col-md-6 col-md-offset-3 text-center">
     <h3><%= current_game.game_name %></h3>
     <br />
+    <h4>Current turn: <%= current_game.current_player.email %>
     <br />
   </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,7 +5,13 @@
   <div class="col-md-6 col-md-offset-3 text-center">
     <h3><%= current_game.game_name %></h3>
     <br />
-    <h4>Current turn: <%= current_game.current_player.email %>
+    <% if current_game.user_turn == current_user.id %>
+      <h4 class="turn-indicator">It is your turn!</h4>
+    <% elsif current_game.user_turn.nil? %>
+      <h4 class="turn-indicator">Waiting for another player to join...</h4>
+    <% else  %>
+      <h4 class="turn-indicator">It is your opponent's turn</h4>
+    <% end %>
     <br />
   </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -6,11 +6,23 @@
     <h3><%= current_game.game_name %></h3>
     <br />
     <% if current_game.user_turn == current_user.id %>
-      <h4 class="turn-indicator">It is your turn!</h4>
-    <% elsif current_game.user_turn.nil? %>
-      <h4 class="turn-indicator">Waiting for another player to join...</h4>
+      <% if current_game.user_turn == current_game.white_user_id %>
+        <h4 class="turn-indicator">It is your turn! (white)</h4>
+      <% else %>
+        <h4 class="turn-indicator">It is your turn! (black)</h4>
+      <% end %>
+    <% elsif current_game.player_missing? %>
+      <% if current_game.white_player_id.nil? %>
+        <h4 class="turn-indicator">Waiting for white player to join...</h4>
+      <% else %>
+        <h4 class="turn-indicator">Waiting for black player to join...</h4>
+      <% end %>
     <% else  %>
-      <h4 class="turn-indicator">It is your opponent's turn</h4>
+      <% if current_game.user_turn == current_game.white_user_id %>
+        <h4 class="turn-indicator">It is your opponent's turn (white)</h4>
+      <% else %>
+        <h4 class="turn-indicator">It is your opponent's turn (black)</h4>
+      <% end %>
     <% end %>
     <br />
   </div>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -5,6 +5,7 @@
   <div class="col-md-6 col-md-offset-3 text-center">
     <h3><%= current_game.game_name %></h3>
     <br />
+    <h4>Current turn: <%= current_game.current_player.email %>
     <br />
   </div>
 </div>

--- a/app/views/welcome/_available_games.html.erb
+++ b/app/views/welcome/_available_games.html.erb
@@ -1,17 +1,25 @@
 <h3>Games players can join:</h3>
 <% @games.each do |game|  %>
   <div class="list-group">
-    <div class="list-group-item">
-      <% if game.player_missing? %>
-        <h4>
-          <%= game.game_name %>
-        </h4>
+    <% if game.player_missing? %>
+      <div class="list-group-item">
+        <h4><%= game.game_name %></h4>
         <%= link_to 'Join Game', game_path(game, id: game.id), method: :patch, :class => 'btn btn-success btn-large join-game-link' %>
-      <% end  %>
-      <br />
-      <br />
-    </div>
+      </div>
+    <% end  %>
+    <br />
   </div>
 <% end %>
 
-<h3>Future list of games players can watch??</h3>
+<h3 class="text-center">Games players can watch:</h3>
+<% @games.each do |game|  %>
+  <div class="list-group">
+    <% if !game.player_missing? %>
+      <div class="list-group-item">
+        <h4><%= game.game_name %></h4>
+        <%= link_to 'Watch Game', game_path(game, id: game.id), :class => 'btn btn-success btn-large join-game-link' %>
+      </div>
+    <% end %>
+    <br />
+  </div>
+<% end %>

--- a/db/migrate/20151220012117_add_user_turn_foreign_key_to_games.rb
+++ b/db/migrate/20151220012117_add_user_turn_foreign_key_to_games.rb
@@ -1,0 +1,11 @@
+class AddUserTurnForeignKeyToGames < ActiveRecord::Migration
+  def up
+    add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"
+  end
+
+  def down
+    change_table :games do |t|
+      t.remove_foreign_key name: "games_user_turn_fk"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151206214122) do
+ActiveRecord::Schema.define(version: 20151220012117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20151206214122) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "games", "users", name: "games_black_user_id_fk", column: "black_user_id"
+  add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"
   add_foreign_key "games", "users", name: "games_white_user_id_fk", column: "white_user_id"
 
   add_foreign_key "pieces", "games", name: "pieces_game_id_fk", dependent: :delete

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe GamesController, type: :controller do
         get :show, id: game.id
         expect(response).to render_template("show")
       end
+      it "shows whose turn it is" do
+        pending "to be implemented"
+        this_should_not_get_executed
+      end
+      it "has current turn set to either white or black user" do
+        pending "to be implemented"
+        this_should_not_get_executed
+      end
     end
     context 'with invalid params' do
       it "has a 404 status code for an non-existant game" do
@@ -68,6 +76,14 @@ RSpec.describe GamesController, type: :controller do
             expect(Game.last.pieces.where(user_id: nil)
               .count).to eq 16
           end
+          it "sets the current user's turn if they are the white player" do
+            pending "to be implemented"
+            this_should_not_get_executed
+          end
+          it "does not set the user's turn if they are black player" do
+            pending "to be implemented"
+            this_should_not_get_executed
+          end
         end
       end
       context 'with invalid params' do
@@ -105,6 +121,10 @@ RSpec.describe GamesController, type: :controller do
           expect(game_to_update.pieces.where(user_id: subject.current_user.id)
             .count).to eq 16
         end
+        it "sets the current user's turn" do
+          pending "to be implemented"
+          this_should_not_get_executed
+        end
       end
       context 'with black player joining game' do
         let(:white_player) { create(:user) }
@@ -122,6 +142,10 @@ RSpec.describe GamesController, type: :controller do
             white_user_id: subject.current_user.id }
           expect(game_to_update.pieces.where(user_id: subject.current_user.id)
             .count).to eq 16
+        end
+        it "does not set the current user's turn" do
+          pending "to be implemented"
+          this_should_not_get_executed
         end
       end
       it 'won\'t let player join full game' do

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -26,14 +26,6 @@ RSpec.describe GamesController, type: :controller do
         get :show, id: game.id
         expect(response).to render_template("show")
       end
-      it "shows whose turn it is" do
-        pending "to be implemented"
-        this_should_not_get_executed
-      end
-      it "has current turn set to either white or black user" do
-        pending "to be implemented"
-        this_should_not_get_executed
-      end
     end
     context 'with invalid params' do
       it "has a 404 status code for an non-existant game" do
@@ -54,16 +46,15 @@ RSpec.describe GamesController, type: :controller do
             expect(response).to redirect_to(Game.last)
           end
           it 'sets all white pieces to be owned by white player' do
-            post :create, game: { game_name: "Test White",
-                                  white_user_id: subject.current_user.id }
+            post :create, game: { game_name: "Test White", creator_plays_as_black: "0" }
             expect(Game.last.pieces.where(user_id: subject.current_user.id)
               .count).to eq 16
             expect(Game.last.pieces.where(user_id: nil)
               .count).to eq 16
           end
           it "sets the current user's turn if they are the white player" do
-            pending "to be implemented"
-            this_should_not_get_executed
+            post :create, game: { game_name: "Test White", creator_plays_as_black: "0" }
+            expect(Game.last.user_turn).to eq(subject.current_user.id)
           end
         end
         context 'with black player creating the game' do
@@ -81,8 +72,9 @@ RSpec.describe GamesController, type: :controller do
               .count).to eq 16
           end
           it "does not set the user's turn if they are black player" do
-            pending "to be implemented"
-            this_should_not_get_executed
+            post :create, game: { game_name: "Test Black",
+                                  creator_plays_as_black: "1" }
+            expect(Game.last.user_turn).to be_nil
           end
         end
       end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe GamesController, type: :controller do
         end
       end
       context 'with invalid params' do
-        it 're-renders #new form' do
+        it 're-renders #new form with bad game name' do
           post :create, game: { game_name: "" }
           expect(response).to render_template(:new)
         end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe GamesController, type: :controller do
           post :create, game: { game_name: "" }
           expect(response).to render_template(:new)
         end
+        it 'raises error with bad user turn id value' do
+          expect{post :create, game: { game_name: "Test Black",
+                                creator_plays_as_black: "1", user_turn: (User.count+1) }}
+                                .to raise_error(ActiveRecord::InvalidForeignKey)
+        end
       end
     end
     context 'without being logged in' do

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe GamesController, type: :controller do
         let(:black_player) { create(:user) }
         let(:game_to_update) do
           Game.create(game_name: "Test",
-                      black_user_id: black_player.id)
+                      black_user_id: black_player.id, user_turn: black_player.id)
         end
         it 'redirects to show page' do
           put :update, id: game_to_update.id, game: {
@@ -110,7 +110,7 @@ RSpec.describe GamesController, type: :controller do
         let(:white_player) { create(:user) }
         let(:game_to_update) do
           Game.create(game_name: "Test",
-                      white_user_id: white_player.id)
+                      white_user_id: white_player.id, user_turn: white_player.id)
         end
         it 'redirects to show page' do
           put :update, id: game_to_update.id, game: {

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -95,23 +95,60 @@ RSpec.describe PiecesController, type: :controller do
       expect(response).to redirect_to(@current_game)
     end
     it "will not allow player to move another player's pieces" do
-      pending "to be implemented"
-      this_should_not_get_executed
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in white_user
+      black_pawn = current_game.pawns.where(color: false, x_position: 0).first
+      put :update, id: black_pawn.id, x: 0, y: 5
+      expect(response).to redirect_to(current_game)
+      expect(flash[:alert]).to be_present
+      expect(flash[:alert]).to match("Not your piece!")
+      expect(black_pawn.x_y_coords).to eq [0,6]
     end
     it "will not let a player move until two players have joined the game" do
-      pending "to be implemented"
-      this_should_not_get_executed
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id, black_user_id: nil)
+      current_game.save!
+      white_user = current_game.white_user
+      sign_in white_user
+      white_pawn = current_game.pawns.where(color: true, x_position: 0).first
+      put :update, id: white_pawn.id, x: 0, y: 2
+      expect(response).to redirect_to(current_game)
+      expect(flash[:alert]).to be_present
+      expect(flash[:alert]).to match("Cannot move until both players have joined!")
+      expect(white_pawn.x_y_coords).to eq [0,1]
     end
     it "will update player turn to other user after move" do
-      pending "to be implemented"
-      this_should_not_get_executed
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in white_user
+      white_pawn = current_game.pawns.where(color: true, x_position: 0).first
+      put :update, id: white_pawn.id, x: 0, y: 2
+      expect(response).to redirect_to(current_game)
+      expect(flash[:alert]).to be_nil
+      white_pawn.reload
+      expect(white_pawn.x_y_coords).to eq [0,2]
+      current_game.reload
+      expect(current_game.user_turn).to eq current_game.black_user_id
     end
   end
 
   describe "#show" do
-    it "will not let a player move until two players have joined the game" do
-      pending "to be implemented"
-      this_should_not_get_executed
+    it "will redirect to game show until two players have joined the game" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id, black_user_id: nil)
+      current_game.save!
+      white_user = current_game.white_user
+      sign_in white_user
+      white_pawn = current_game.pawns.where(color: true, x_position: 0).first
+      put :show, id: white_pawn.id
+      expect(response).to redirect_to(current_game)
     end
   end
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -94,6 +94,25 @@ RSpec.describe PiecesController, type: :controller do
       expect(knight.x_y_coords).to eq [6, 6]
       expect(response).to redirect_to(@current_game)
     end
+    it "will not allow player to move another player's pieces" do
+      pending "to be implemented"
+      this_should_not_get_executed
+    end
+    it "will not let a player move until two players have joined the game" do
+      pending "to be implemented"
+      this_should_not_get_executed
+    end
+    it "will update player turn to other user after move" do
+      pending "to be implemented"
+      this_should_not_get_executed
+    end
+  end
+
+  describe "#show" do
+    it "will not let a player move until two players have joined the game" do
+      pending "to be implemented"
+      this_should_not_get_executed
+    end
   end
 
   end

--- a/spec/models/bishop_spec.rb
+++ b/spec/models/bishop_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Bishop, type: :model do
         # can't move off the board
         expect(bishop.valid_move?(-1, 1)).to be false
         # can't move onto tile of same colored piece
-        expect{bishop.valid_move?(3, 1)}.to raise_error(RuntimeError)
+        expect(bishop.valid_move?(3, 1)).to be false
       end
     end
   end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe Piece, type: :model do
         board = create(:game)
         board.pieces.delete_all
         white_king = King.create(x_position: 1, y_position: 1,
-                                 game_id: board.id, color: true)
+                                 game_id: board.id, color: true, user_id: board.white_user_id)
 
-        expect { white_king.move_to!(3, 3) }
-          .to raise_error(/Invalid/)
+        expect(white_king.move_to!(3, 3)).to eq false
+        expect(white_king.flash_message).to match(/Invalid move/)
       end
     end
     context "when the pieces are of the same color" do
@@ -103,8 +103,8 @@ RSpec.describe Piece, type: :model do
         white_knight = Knight.create(x_position: 2, y_position: 2,
                                      game_id: board.id, color: true)
 
-        expect { white_king.move_to!(2, 2) }
-          .to raise_error(/Invalid/)
+        expect(white_king.move_to!(2, 2)).to eq false
+        expect(white_king.flash_message).to match(/Invalid move/)
       end
     end
   end
@@ -169,9 +169,9 @@ RSpec.describe Piece, type: :model do
       )
     end
 
-    it 'will raise an Error Message with invalid input' do
-      expect { @white_queen.is_obstructed?(4, 3) }
-        .to raise_error("Invalid input or invalid move.")
+    it 'will flash an Error Message with invalid input' do
+      expect(@white_queen.is_obstructed?(4, 3)).to eq true
+      expect(@white_queen.flash_message).to match("Invalid input or invalid move.")
     end
 
     it 'will be false when horizontal axis path is clear' do


### PR DESCRIPTION
Sets up game to flow through player turns. If a bad/invalid move is made, it remains the current players' turn and a flash error message is displayed. If the move is valid, then the move is committed and the turn changes to the other player. A player can only move their own pieces, and only during their own turn. A player can not move if they are the only user in the game (they must wait for another player to join). Fixed up game listing page to allow full games to be viewed by spectators (a current player of a game can also get back to their own game this way). A message on the game show page will say whether it is the current players' turn, the opponent's turn, or they are waiting for another player to join the game. Added tests for this functionality (although I'm sure we can always add more...)

Make sure to run a migration since a foreign key was added to the database for user_turn
