### PR TITLE
Jg/checkmate turn logic

### DIFF
--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -6,7 +6,10 @@ class King < Piece
                  .where("x_position = ? AND y_position = ?", dest_x, dest_y)
                  .take
     return false if dest_x < 0 || dest_x > 7 || dest_y < 0 || dest_y > 7
-    return false if dest_piece && dest_piece.color == color
+    if dest_piece && dest_piece.color == color
+      self.flash_message = "Can't move on top of your own piece!"
+      return false 
+    end
     rows <= 1 && columns <= 1 ? true : false
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -44,6 +44,10 @@ class Piece < ActiveRecord::Base
       self.flash_message = "Invalid move: [error to be defined]"
       return false
     end
+    if game.puts_king_in_check?(self, x, y) # putting this in for now, will update when sharon's branch is merged
+      self.flash_message = "Can't put yourself in check!"
+      return false 
+    end
     if @target.nil?
       update_attributes(:x_position => x, :y_position => y, :has_moved => true)
     else

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -41,11 +41,11 @@ class Piece < ActiveRecord::Base
   def move_to!(x, y)
     @target = game.pieces.where(:x_position => x, :y_position => y).take
     unless valid_move?(x, y)
-      self.flash_message = "Invalid move: [error to be defined]"
+      self.flash_message = "Invalid move!"
       return false
     end
     if game.puts_king_in_check?(self, x, y) # putting this in for now, will update when sharon's branch is merged
-      self.flash_message = "Can't put yourself in check!"
+      self.flash_message = "Can't put or leave yourself in check!"
       return false 
     end
     if @target.nil?

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -7,9 +7,9 @@
     <br />
     <% if !current_game.game_winner.nil? %>
       <% if current_game.game_winner == current_game.white_user_id %>
-        <h4 class="turn-indicator">Game over, white player wins!</h4>
+        <h4 class="turn-indicator">Checkmate! White player wins!</h4>
       <% else %>
-        <h4 class="turn-indicator">Game over, black player wins!</h4>
+        <h4 class="turn-indicator">Checkmate! Black player wins!</h4>
       <% end %>
     <% elsif current_game.user_turn == current_user.id %>
       <% if current_game.user_turn == current_game.white_user_id %>
@@ -18,7 +18,7 @@
         <h4 class="turn-indicator">It is your turn! (black)</h4>
       <% end %>
     <% elsif current_game.player_missing? %>
-      <% if current_game.white_player_id.nil? %>
+      <% if current_game.white_user_id.nil? %>
         <h4 class="turn-indicator">Waiting for white player to join...</h4>
       <% else %>
         <h4 class="turn-indicator">Waiting for black player to join...</h4>
@@ -31,8 +31,8 @@
       <% end %>
     <% end %>
     <br />
-    <% if current_game.check? %>
-      <% if current_game.user_turn == current_game.white_player_id %>
+    <% if current_game.check? && current_game.game_winner.nil?%>
+      <% if current_game.user_turn == current_game.white_user_id %>
         <h4 class ="check-message">White player is in check!</h4>
       <% else %>
         <h4 class ="check-message">Black player is in check!</h4>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,7 +5,13 @@
   <div class="col-md-6 col-md-offset-3 text-center">
     <h3><%= current_game.game_name %></h3>
     <br />
-    <% if current_game.user_turn == current_user.id %>
+    <% if !current_game.game_winner.nil? %>
+      <% if current_game.game_winner == current_game.white_user_id %>
+        <h4 class="turn-indicator">Game over, white player wins!</h4>
+      <% else %>
+        <h4 class="turn-indicator">Game over, black player wins!</h4>
+      <% end %>
+    <% elsif current_game.user_turn == current_user.id %>
       <% if current_game.user_turn == current_game.white_user_id %>
         <h4 class="turn-indicator">It is your turn! (white)</h4>
       <% else %>
@@ -25,6 +31,13 @@
       <% end %>
     <% end %>
     <br />
+    <% if current_game.check? %>
+      <% if current_game.user_turn == current_game.white_player_id %>
+        <h4 class ="check-message">White player is in check!</h4>
+      <% else %>
+        <h4 class ="check-message">Black player is in check!</h4>
+      <% end %>
+    <% end %>
   </div>
 </div>
 <table class="chessboard">

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -7,9 +7,9 @@
     <br />
     <% if !current_game.game_winner.nil? %>
       <% if current_game.game_winner == current_game.white_user_id %>
-        <h4 class="turn-indicator">Game over, white player wins!</h4>
+        <h4 class="turn-indicator">Checkmate! White player wins!</h4>
       <% else %>
-        <h4 class="turn-indicator">Game over, black player wins!</h4>
+        <h4 class="turn-indicator">Checkmate! Black player wins!</h4>
       <% end %>
     <% elsif current_game.user_turn == current_user.id %>
       <% if current_game.user_turn == current_game.white_user_id %>
@@ -18,7 +18,7 @@
         <h4 class="turn-indicator">It is your turn! (black)</h4>
       <% end %>
     <% elsif current_game.player_missing? %>
-      <% if current_game.white_player_id.nil? %>
+      <% if current_game.white_user_id.nil? %>
         <h4 class="turn-indicator">Waiting for white player to join...</h4>
       <% else %>
         <h4 class="turn-indicator">Waiting for black player to join...</h4>
@@ -31,8 +31,8 @@
       <% end %>
     <% end %>
     <br />
-    <% if current_game.check? %>
-      <% if current_game.user_turn == current_game.white_player_id %>
+    <% if current_game.check? && current_game.game_winner.nil?%>
+      <% if current_game.user_turn == current_game.white_user_id %>
         <h4 class ="check-message">White player is in check!</h4>
       <% else %>
         <h4 class ="check-message">Black player is in check!</h4>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -5,8 +5,39 @@
   <div class="col-md-6 col-md-offset-3 text-center">
     <h3><%= current_game.game_name %></h3>
     <br />
-    <h4>Current turn: <%= current_game.current_player.email %>
+    <% if !current_game.game_winner.nil? %>
+      <% if current_game.game_winner == current_game.white_user_id %>
+        <h4 class="turn-indicator">Game over, white player wins!</h4>
+      <% else %>
+        <h4 class="turn-indicator">Game over, black player wins!</h4>
+      <% end %>
+    <% elsif current_game.user_turn == current_user.id %>
+      <% if current_game.user_turn == current_game.white_user_id %>
+        <h4 class="turn-indicator">It is your turn! (white)</h4>
+      <% else %>
+        <h4 class="turn-indicator">It is your turn! (black)</h4>
+      <% end %>
+    <% elsif current_game.player_missing? %>
+      <% if current_game.white_player_id.nil? %>
+        <h4 class="turn-indicator">Waiting for white player to join...</h4>
+      <% else %>
+        <h4 class="turn-indicator">Waiting for black player to join...</h4>
+      <% end %>
+    <% else  %>
+      <% if current_game.user_turn == current_game.white_user_id %>
+        <h4 class="turn-indicator">It is your opponent's turn (white)</h4>
+      <% else %>
+        <h4 class="turn-indicator">It is your opponent's turn (black)</h4>
+      <% end %>
+    <% end %>
     <br />
+    <% if current_game.check? %>
+      <% if current_game.user_turn == current_game.white_player_id %>
+        <h4 class ="check-message">White player is in check!</h4>
+      <% else %>
+        <h4 class ="check-message">Black player is in check!</h4>
+      <% end %>
+    <% end %>
   </div>
 </div>
 <table class="chessboard">

--- a/db/migrate/20151223044337_add_game_winner_to_games.rb
+++ b/db/migrate/20151223044337_add_game_winner_to_games.rb
@@ -1,0 +1,13 @@
+class AddGameWinnerToGames < ActiveRecord::Migration
+  def up
+    add_column :games, :game_winner, :integer
+    add_foreign_key "games", "users", name: "games_game_winner_fk", column: "game_winner"
+  end
+
+  def down
+    change_table :games do |t|
+      t.remove_foreign_key name: "games_game_winner_fk"
+    end
+    remove_column :games, :game_winner, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151220012117) do
+ActiveRecord::Schema.define(version: 20151223044337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20151220012117) do
     t.integer  "check_status"
     t.integer  "white_user_id"
     t.integer  "black_user_id"
+    t.integer  "game_winner"
   end
 
   add_index "games", ["black_user_id"], name: "index_games_on_black_user_id", using: :btree
@@ -62,6 +63,7 @@ ActiveRecord::Schema.define(version: 20151220012117) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "games", "users", name: "games_black_user_id_fk", column: "black_user_id"
+  add_foreign_key "games", "users", name: "games_game_winner_fk", column: "game_winner"
   add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"
   add_foreign_key "games", "users", name: "games_white_user_id_fk", column: "white_user_id"
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe PiecesController, type: :controller do
                                  game_id: @current_game.id, color: true, user_id: @current_game.white_user_id)
         black_knight = Knight.create(x_position: 2, y_position: 2,
                                      game_id: @current_game.id, color: false, user_id: @current_game.black_user_id)
+        # need both kings for checkmate logic
+        black_king = King.create(x_position: 7, y_position: 7,
+                                     game_id: @current_game.id, color: false, user_id: @current_game.black_user_id)
         put :update, id: white_king.id, x: 2, y: 2
         white_king.reload
         black_knight.reload
@@ -54,28 +57,35 @@ RSpec.describe PiecesController, type: :controller do
     end
     context "when the tile is empty" do
       it "moves to the coordinates" do
-        king = King.create(x_position: 1, y_position: 1, game_id: @current_game.id, user_id: @current_game.white_user_id)
-        put :update, id: king.id, x: 2, y: 2
-        king.reload
-        expect(king.x_position).to eq(2)
-        expect(king.y_position).to eq(2)
+        # need both kings for checkmate logic
+        black_king = King.create(x_position: 7, y_position: 7, game_id: @current_game.id, user_id: @current_game.black_user_id, color: false)
+        white_king = King.create(x_position: 1, y_position: 1, game_id: @current_game.id, user_id: @current_game.white_user_id, color: true)
+        put :update, id: white_king.id, x: 2, y: 2
+        white_king.reload
+        expect(white_king.x_position).to eq(2)
+        expect(white_king.y_position).to eq(2)
       end
       it "moves 2 spaces up" do
-        king = King.create(x_position: 1, y_position: 1, game_id: @current_game.id, user_id: @current_game.white_user_id)
-        put :update, id: king.id, x: 2, y: 2
+        # need both kings for checkmate logic
+        black_king = King.create(x_position: 7, y_position: 7, game_id: @current_game.id, user_id: @current_game.black_user_id, color: false)
+        white_king = King.create(x_position: 1, y_position: 1, game_id: @current_game.id, user_id: @current_game.white_user_id, color: true)
+        put :update, id: white_king.id, x: 2, y: 2
         expected_x_y_coords = [2, 2]
-        king.reload
-        expect(king.x_y_coords).to eql(expected_x_y_coords)
+        white_king.reload
+        expect(white_king.x_y_coords).to eq(expected_x_y_coords)
       end
 
       it "will move 2 spaces up and 1 space right" do
-        knight = Knight.create(x_position: 0, y_position: 0, game_id: @current_game.id, user_id: @current_game.white_user_id)
-        put :update, id: knight.id, x: 1, y: 2
+        # need both kings for checkmate logic
+        black_king = King.create(x_position: 7, y_position: 7, game_id: @current_game.id, user_id: @current_game.black_user_id, color: false)
+        white_king = King.create(x_position: 5, y_position: 5, game_id: @current_game.id, user_id: @current_game.white_user_id, color: true)
+        white_knight = Knight.create(x_position: 0, y_position: 0, game_id: @current_game.id, user_id: @current_game.white_user_id, color: true)
+        put :update, id: white_knight.id, x: 1, y: 2
         expected_x_position = 1
         expected_y_position = 2
-        knight.reload
-        expect(knight.x_position).to be(expected_x_position)
-        expect(knight.y_position).to be(expected_y_position)
+        white_knight.reload
+        expect(white_knight.x_position).to be(expected_x_position)
+        expect(white_knight.y_position).to be(expected_y_position)
       end
     end
   end
@@ -137,6 +147,25 @@ RSpec.describe PiecesController, type: :controller do
       current_game.reload
       expect(current_game.user_turn).to eq current_game.black_user_id
     end
+    it "will set winner when they place opposing king in checkmate" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.black_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in black_user
+      current_game.pieces.delete_all
+      white_king = King.create(color: true, game_id: current_game.id, user_id: current_game.white_user_id, x_position: 0, y_position: 0)
+      black_king = King.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 7, y_position: 7)
+      black_queen = Queen.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 6, y_position: 1)
+      black_pawn = Pawn.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 2, y_position: 2)
+      expect(current_game.game_winner).to be_nil
+      put :update, id: black_queen.id, x: 1, y: 1
+      current_game.reload
+      expect(current_game.game_winner).to eq current_game.black_user_id
+      expect(flash[:alert]).to eq("Black wins!")
+      expect(response).to redirect_to(current_game)
+    end
   end
 
   describe "#show" do
@@ -149,6 +178,17 @@ RSpec.describe PiecesController, type: :controller do
       white_pawn = current_game.pawns.where(color: true, x_position: 0).first
       put :show, id: white_pawn.id
       expect(response).to redirect_to(current_game)
+    end
+    it "will redirect to game show when a player has won" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id, game_winner: current_game.black_user_id)
+      current_game.save!
+      white_user = current_game.white_user
+      sign_in white_user
+      white_pawn = current_game.pawns.where(color: true, x_position: 0).first
+      put :show, id: white_pawn.id
+      expect(response).to redirect_to(current_game)
+      expect(flash[:alert]).to eq("Game is over, black wins!")
     end
   end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -438,9 +438,9 @@ RSpec.describe Game, type: :model do
         expect(@game.checkmate?(black_king)).to eq true
       end
       it "if in check and no valid moves to get out - example 5" do
-        white_king = King.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 0, y_position: 0)
-        black_queen = Queen.create(color: false, game_id: @game.id, user_id: @game.white_user_id, x_position: 1, y_position: 1)
-        black_pawn = Pawn.create(color: false, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 2)
+        white_king = King.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 0, y_position: 0)
+        black_queen = Queen.create(color: false, game_id: @game.id, user_id: @game.black_user_id, x_position: 1, y_position: 1)
+        black_pawn = Pawn.create(color: false, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 2)
         expect(@game.checkmate?(white_king)).to eq true # pawns must be on correct side of board!
       end
       it "if in check and no valid moves to get out - example 6" do
@@ -522,24 +522,24 @@ RSpec.describe Game, type: :model do
       end
       it "if in check and friendly piece can capture threatening piece - example 1" do
         # black pawn can capture white knight
-        white_king = King.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 1, y_position: 0)
-        white_pawn1 = Pawn.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 0, y_position: 1)
-        white_pawn2 = Pawn.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 1, y_position: 1)
-        white_pawn3 = Pawn.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 1)
-        white_rook = Rook.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 0, y_position: 0)
-        white_bishop = Bishop.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 0)
-        black_knight = Knight.create(color: false, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 2)
+        white_king = King.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 1, y_position: 0)
+        white_pawn1 = Pawn.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 0, y_position: 1)
+        white_pawn2 = Pawn.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 1, y_position: 1)
+        white_pawn3 = Pawn.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 1)
+        white_rook = Rook.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 0, y_position: 0)
+        white_bishop = Bishop.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 0)
+        black_knight = Knight.create(color: false, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 2)
         expect(@game.checkmate?(white_king)).to eq false # pawns have to be on the correct side!
         expect(black_knight.captured?).to eq false # make sure piece isn't actually captured by the test
       end
       it "if in check and friendly piece can capture threatening piece - example 2" do
         # black queen can capture white knight
-        white_king = King.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 1, y_position: 0)
-        white_pawn = Pawn.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 0, y_position: 1)
-        white_rook = Rook.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 0, y_position: 0)
-        white_queen = Queen.create(color: true, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 0)
-        black_knight = Knight.create(color: false, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 2)
-        black_queen = Queen.create(color: false, game_id: @game.id, user_id: @game.white_user_id, x_position: 4, y_position: 1)
+        white_king = King.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 1, y_position: 0)
+        white_pawn = Pawn.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 0, y_position: 1)
+        white_rook = Rook.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 0, y_position: 0)
+        white_queen = Queen.create(color: true, game_id: @game.id, user_id: @game.white_user_id, x_position: 2, y_position: 0)
+        black_knight = Knight.create(color: false, game_id: @game.id, user_id: @game.black_user_id, x_position: 2, y_position: 2)
+        black_queen = Queen.create(color: false, game_id: @game.id, user_id: @game.black_user_id, x_position: 4, y_position: 1)
         expect(@game.checkmate?(white_king)).to eq false # pawns have to be on the correct side!
         expect(black_knight.captured?).to eq false # make sure piece isn't actually captured by the test
       end


### PR DESCRIPTION
This PR is intended to be merged after #69 as this builds off of that code base. Puts all the turn logic in place to be able to play an (almost, still need stuff like pawn promotion and en passant, etc) fully-fledged game of chess. When a player wins, the game show page is updated to reflect this, and no more moves are allowed to be made (with an appropriate flash error message)
