### PR TITLE
Jg/en passant

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,7 @@
 class Game < ActiveRecord::Base
   attr_accessor :creator_plays_as_black # for checkbox access
   has_many :pieces
+  has_one  :last_moved_piece, class_name: 'Piece', foreign_key: :last_moved_piece
   belongs_to :white_user, class_name: 'User', foreign_key: :white_user_id
   belongs_to :black_user, class_name: 'User', foreign_key: :black_user_id
   validates :game_name, presence: { :message => "Game name is required!" }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,7 +1,7 @@
 class Game < ActiveRecord::Base
   attr_accessor :creator_plays_as_black # for checkbox access
   has_many :pieces
-  has_one  :last_moved_piece, class_name: 'Piece', foreign_key: :last_moved_piece
+  has_one  :last_moved_piece, class_name: 'Piece', foreign_key: :last_moved_piece_id
   belongs_to :white_user, class_name: 'User', foreign_key: :white_user_id
   belongs_to :black_user, class_name: 'User', foreign_key: :black_user_id
   validates :game_name, presence: { :message => "Game name is required!" }

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -6,6 +6,7 @@ class Pawn < Piece
     return false if is_obstructed?(dest_x, dest_y)
     return false if dest_x < 0 || dest_x > 7 || dest_y < 0 || dest_y > 7
     return false if dest_piece && dest_piece.color == color
+    return true if en_passant?(dest_x, dest_y)
     (one_forward(dest_x, dest_y) && dest_piece.nil?) ||
     (two_forward(dest_x, dest_y) && dest_piece.nil?) ||
     (one_diagonal(dest_x, dest_y) && !dest_piece.nil?)
@@ -37,5 +38,24 @@ class Pawn < Piece
     else
       dest_y == y_position - 1 && (dest_x == x_position + 1 || dest_x == x_position - 1)
     end
+  end
+
+  def en_passant?(dest_x, dest_y)
+    # has to move one space forward diagonal left or right
+    return false unless one_diagonal(dest_x, dest_y)
+    adjacent_right = game.pieces.where(x_position: x_position + 1, y_position: y_position, piece_type: "Pawn").first
+    adjacent_left = game.pieces.where(x_position: x_position - 1, y_position: y_position, piece_type: "Pawn").first
+    # must have a pawn adjacent
+    return false unless adjacent_left || adjacent_right
+    if dest_x < x_position && adjacent_left # moving diagonal left with enemy pawn to left
+      return false unless game.last_moved_piece_id == adjacent_left.id # enemy pawn has to be last piece moved
+      return false unless (game.last_moved_prev_y_pos - adjacent_left.y_position).abs == 2 # has to be 2 space move
+      return adjacent_left # will evaluate to true, can be used for capture logic later
+    elsif dest_x > x_position && adjacent_right # moving diagonal right with enemy pawn to right
+      return false unless game.last_moved_piece_id == adjacent_right.id # enemy pawn has to be last piece moved
+      return false unless (game.last_moved_prev_y_pos - adjacent_right.y_position).abs == 2 # has to be 2 space move
+      return adjacent_right # will evaluate to true, can be used for capture logic later
+    end
+    return false
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -39,6 +39,8 @@ class Piece < ActiveRecord::Base
   end
 
   def move_to!(x, y)
+    orig_x = self.x_position
+    orig_y = self.y_position
     @target = game.pieces.where(:x_position => x, :y_position => y).take
     unless valid_move?(x, y)
       self.flash_message = "Invalid move!"
@@ -48,21 +50,25 @@ class Piece < ActiveRecord::Base
       self.flash_message = "Can't put or leave yourself in check!"
       return false 
     end
-    if @target.nil?
+    if self.piece_type == "Pawn" && self.en_passant?(x, y)
+      capture(self.en_passant?(x, y), x, y) #en_passant? returns captured piece
+    elsif @target.nil?
       update_attributes(:x_position => x, :y_position => y, :has_moved => true)
     else
       if color == @target.color
         self.flash_message =  "Invalid move: same color piece"
         return false
       end
-      capture(x, y)
+      capture(@target, x, y)
     end
+    game.update_attributes(last_moved_piece_id: self.id, last_moved_prev_x_pos: orig_x, last_moved_prev_y_pos: orig_y)
     return true
   end
 
-  def capture(x, y)
+  def capture(target, x, y)
+    # target is the piece to capture. x and y are capturing piece destination
     update_attributes(:x_position => x, :y_position => y, :has_moved => true)
-    @target.update_attributes(:captured => true, :x_position => nil,
+    target.update_attributes(:captured => true, :x_position => nil,
                               :y_position => nil)
   end
 

--- a/db/migrate/20151223044337_add_game_winner_to_games.rb
+++ b/db/migrate/20151223044337_add_game_winner_to_games.rb
@@ -8,6 +8,6 @@ class AddGameWinnerToGames < ActiveRecord::Migration
     change_table :games do |t|
       t.remove_foreign_key name: "games_game_winner_fk"
     end
-    remove_column :games, :game_winner, :integer
+    remove_column :games, :game_winner
   end
 end

--- a/db/migrate/20151225120113_add_last_move_info_to_games.rb
+++ b/db/migrate/20151225120113_add_last_move_info_to_games.rb
@@ -1,0 +1,16 @@
+class AddLastMoveInfoToGames < ActiveRecord::Migration
+  def up
+    add_column :games, :last_moved_piece, :integer
+    add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece"
+    add_column :games, :last_moved_prev_x_pos, :integer
+    add_column :games, :last_moved_prev_y_pos, :integer
+  end
+  def down
+    change_table :games do |t|
+      t.remove_foreign_key name: "games_last_moved_piece_fk"
+    end
+    remove_column :games, :last_moved_piece
+    remove_column :games, :last_moved_prev_x_pos
+    remove_column :games, :last_moved_prev_y_pos
+  end
+end

--- a/db/migrate/20151225120113_add_last_move_info_to_games.rb
+++ b/db/migrate/20151225120113_add_last_move_info_to_games.rb
@@ -1,7 +1,7 @@
 class AddLastMoveInfoToGames < ActiveRecord::Migration
   def up
-    add_column :games, :last_moved_piece, :integer
-    add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece"
+    add_column :games, :last_moved_piece_id, :integer
+    add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece_id"
     add_column :games, :last_moved_prev_x_pos, :integer
     add_column :games, :last_moved_prev_y_pos, :integer
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,8 +25,7 @@ ActiveRecord::Schema.define(version: 20151225120113) do
     t.integer  "white_user_id"
     t.integer  "black_user_id"
     t.integer  "game_winner"
-    t.boolean  "draw",                  default: false
-    t.integer  "last_moved_piece"
+    t.integer  "last_moved_piece_id"
     t.integer  "last_moved_prev_x_pos"
     t.integer  "last_moved_prev_y_pos"
   end
@@ -66,7 +65,7 @@ ActiveRecord::Schema.define(version: 20151225120113) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
-  add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece"
+  add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece_id"
   add_foreign_key "games", "users", name: "games_black_user_id_fk", column: "black_user_id"
   add_foreign_key "games", "users", name: "games_game_winner_fk", column: "game_winner"
   add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151223044337) do
+ActiveRecord::Schema.define(version: 20151225120113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,10 @@ ActiveRecord::Schema.define(version: 20151223044337) do
     t.integer  "white_user_id"
     t.integer  "black_user_id"
     t.integer  "game_winner"
+    t.boolean  "draw",                  default: false
+    t.integer  "last_moved_piece"
+    t.integer  "last_moved_prev_x_pos"
+    t.integer  "last_moved_prev_y_pos"
   end
 
   add_index "games", ["black_user_id"], name: "index_games_on_black_user_id", using: :btree
@@ -62,6 +66,7 @@ ActiveRecord::Schema.define(version: 20151223044337) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece"
   add_foreign_key "games", "users", name: "games_black_user_id_fk", column: "black_user_id"
   add_foreign_key "games", "users", name: "games_game_winner_fk", column: "game_winner"
   add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -166,6 +166,47 @@ RSpec.describe PiecesController, type: :controller do
       expect(flash[:alert]).to eq("Black wins!")
       expect(response).to redirect_to(current_game)
     end
+    it "updates game last moved piece id and previous coordinates" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.white_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in white_user
+      current_game.pieces.delete_all
+      # need both kings
+      black_king = King.create(x_position: 7, y_position: 7, game_id: current_game.id, color: false, user_id: current_game.black_user_id)
+      white_king = King.create(x_position: 0, y_position: 0, game_id: current_game.id, color: true, user_id: current_game.white_user_id)
+      white_pawn = Pawn.create(x_position: 5, y_position: 1, game_id: current_game.id, color: true, user_id: current_game.white_user_id)
+      put :update, id: white_pawn.id, x: 5, y: 3 # double space first move
+      current_game.reload
+      expect(current_game.last_moved_piece_id).to eq white_pawn.id
+      expect(current_game.last_moved_prev_x_pos).to eq 5
+      expect(current_game.last_moved_prev_y_pos).to eq 1
+    end
+    context "pawn en passant" do
+      it "captures enemy pawn after move" do
+        current_game = FactoryGirl.build(:game)
+        current_game.assign_attributes(user_turn: current_game.white_user_id)
+        current_game.save!
+        black_user = current_game.black_user
+        white_user = current_game.white_user
+        sign_in white_user
+        current_game.pieces.delete_all
+        # need both kings
+        black_king = King.create(x_position: 7, y_position: 7, game_id: current_game.id, color: false, user_id: current_game.black_user_id)
+        white_king = King.create(x_position: 0, y_position: 0, game_id: current_game.id, color: true, user_id: current_game.white_user_id)
+        black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: current_game.id, color: false, has_moved: true, user_id: current_game.black_user_id)
+        current_game.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+        white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: current_game.id, color: true, has_moved: true, user_id: current_game.white_user_id)
+        expect(black_pawn.captured?).to be false
+        expect(black_pawn.x_y_coords).to eq [4, 4]
+        put :update, id: white_pawn.id, x: 4, y: 5
+        black_pawn.reload
+        expect(black_pawn.captured?).to be true
+        expect(black_pawn.x_y_coords).to eq [nil, nil]
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -209,16 +209,60 @@ RSpec.describe Pawn, type: :model do
       end
       context "en passant" do
         it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - left" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(4, 5)).to be true
         end
         it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - right" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          black_pawn = Pawn.create(x_position: 6, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 6)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(6, 5)).to be true
         end
         it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - left" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          black_king = King.create(x_position: 0, y_position: 7, game_id: board.id, color: false, has_moved: true)
+          black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(4, 5)).to be false
         end
         it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - right" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          black_king = King.create(x_position: 0, y_position: 7, game_id: board.id, color: false, has_moved: true)
+          black_pawn = Pawn.create(x_position: 6, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(6, 5)).to be false
+        end
+        it "will not allow move if enemy pawn only moved one space" do
+          board = create(:game)
+          board.pieces.delete_all
+          black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 5)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(4, 5)).to be false
+        end
+        it "will not allow move if enemy piece is not a pawn" do
+          board = create(:game)
+          board.pieces.delete_all
+          black_queen = Queen.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
+          board.update_attributes(last_moved_piece_id: black_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+          board.reload
+          expect(white_pawn.valid_move?(4, 5)).to be false
         end
       end
     end
@@ -415,16 +459,60 @@ RSpec.describe Pawn, type: :model do
       end
       context "en passant" do
         it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - left" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(4, 2)).to be true
         end
         it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - right" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          white_pawn = Pawn.create(x_position: 6, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 1)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(6, 2)).to be true
         end
         it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - left" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          white_king = King.create(x_position: 0, y_position: 0, game_id: board.id, color: true, has_moved: true)
+          white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(4, 2)).to be false
         end
         it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - right" do
-          
+          board = create(:game)
+          board.pieces.delete_all
+          white_king = King.create(x_position: 0, y_position: 0, game_id: board.id, color: true, has_moved: true)
+          white_pawn = Pawn.create(x_position: 6, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(6, 2)).to be false
+        end
+        it "will not allow move if enemy pawn only moved one space" do
+          board = create(:game)
+          board.pieces.delete_all
+          white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 2)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(4, 5)).to be false
+        end
+        it "will not allow move if enemy piece is not a pawn" do
+          board = create(:game)
+          board.pieces.delete_all
+          white_queen = Queen.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
+          board.update_attributes(last_moved_piece_id: white_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
+          board.reload
+          expect(black_pawn.valid_move?(4, 2)).to be false
         end
       end
     end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -212,7 +212,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          board.assign_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(4, 5)).to be true
@@ -221,7 +222,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           black_pawn = Pawn.create(x_position: 6, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 6)
+          board.assign_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 6)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(6, 5)).to be true
@@ -231,7 +233,8 @@ RSpec.describe Pawn, type: :model do
           board.pieces.delete_all
           black_king = King.create(x_position: 0, y_position: 7, game_id: board.id, color: false, has_moved: true)
           black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          board.assign_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(4, 5)).to be false
@@ -241,7 +244,8 @@ RSpec.describe Pawn, type: :model do
           board.pieces.delete_all
           black_king = King.create(x_position: 0, y_position: 7, game_id: board.id, color: false, has_moved: true)
           black_pawn = Pawn.create(x_position: 6, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          board.assign_attributes(last_moved_piece_id: black_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 7)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(6, 5)).to be false
@@ -250,7 +254,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 5)
+          board.assign_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 5)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(4, 5)).to be false
@@ -259,7 +264,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           black_queen = Queen.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
-          board.update_attributes(last_moved_piece_id: black_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          board.assign_attributes(last_moved_piece_id: black_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+          board.save(validate: false)
           white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
           board.reload
           expect(white_pawn.valid_move?(4, 5)).to be false
@@ -462,7 +468,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          board.assign_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
           expect(black_pawn.valid_move?(4, 2)).to be true
@@ -471,7 +478,8 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           white_pawn = Pawn.create(x_position: 6, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 1)
+          board.assign_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 6, last_moved_prev_y_pos: 1)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
           expect(black_pawn.valid_move?(6, 2)).to be true
@@ -481,7 +489,8 @@ RSpec.describe Pawn, type: :model do
           board.pieces.delete_all
           white_king = King.create(x_position: 0, y_position: 0, game_id: board.id, color: true, has_moved: true)
           white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          board.assign_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
           expect(black_pawn.valid_move?(4, 2)).to be false
@@ -491,7 +500,8 @@ RSpec.describe Pawn, type: :model do
           board.pieces.delete_all
           white_king = King.create(x_position: 0, y_position: 0, game_id: board.id, color: true, has_moved: true)
           white_pawn = Pawn.create(x_position: 6, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          board.assign_attributes(last_moved_piece_id: white_king.id, last_moved_prev_x_pos: 1, last_moved_prev_y_pos: 0)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
           expect(black_pawn.valid_move?(6, 2)).to be false
@@ -500,16 +510,18 @@ RSpec.describe Pawn, type: :model do
           board = create(:game)
           board.pieces.delete_all
           white_pawn = Pawn.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 2)
+          board.assign_attributes(last_moved_piece_id: white_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 2)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
-          expect(black_pawn.valid_move?(4, 5)).to be false
+          expect(black_pawn.valid_move?(4, 2)).to be false
         end
         it "will not allow move if enemy piece is not a pawn" do
           board = create(:game)
           board.pieces.delete_all
           white_queen = Queen.create(x_position: 4, y_position: 3, game_id: board.id, color: true, has_moved: true)
-          board.update_attributes(last_moved_piece_id: white_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          board.assign_attributes(last_moved_piece_id: white_queen.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 1)
+          board.save(validate: false)
           black_pawn = Pawn.create(x_position: 5, y_position: 3, game_id: board.id, color: false, has_moved: true)
           board.reload
           expect(black_pawn.valid_move?(4, 2)).to be false

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -207,6 +207,20 @@ RSpec.describe Pawn, type: :model do
         actual = pawn.valid_move?(1, -1)
         expect(actual).to be(false)
       end
+      context "en passant" do
+        it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - left" do
+          
+        end
+        it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - right" do
+          
+        end
+        it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - left" do
+          
+        end
+        it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - right" do
+          
+        end
+      end
     end
 
     context "black moving" do
@@ -398,6 +412,20 @@ RSpec.describe Pawn, type: :model do
         board.reload
         actual = pawn.valid_move?(6, 8)
         expect(actual).to be(false)
+      end
+      context "en passant" do
+        it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - left" do
+          
+        end
+        it "will let adjacent pawn capture enemy pawn that moved 2 spaces as immediate next move - right" do
+          
+        end
+        it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - left" do
+          
+        end
+        it "will not let adjacent pawn capture enemy pawn that moved 2 spaces if not the immediate next move - right" do
+          
+        end
       end
     end
   end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe Piece, type: :model do
         expect(white_king.flash_message).to match(/Invalid move/)
       end
     end
+    context "pawn en passant" do
+      it "captures enemy pawn after move" do
+        board = create(:game)
+        board.pieces.delete_all
+        black_pawn = Pawn.create(x_position: 4, y_position: 4, game_id: board.id, color: false, has_moved: true)
+        board.update_attributes(last_moved_piece_id: black_pawn.id, last_moved_prev_x_pos: 4, last_moved_prev_y_pos: 6)
+        white_pawn = Pawn.create(x_position: 5, y_position: 4, game_id: board.id, color: true, has_moved: true)
+        board.reload
+        expect(black_pawn.captured?).to be false
+        expect(black_pawn.x_y_coords).to eq [4, 4]
+        expect(white_pawn.move_to!(4, 5)).to be true
+        expect(black_pawn.captured?).to be true
+        expect(black_pawn.x_y_coords).to eq [nil, nil]
+      end
+    end
   end
 
   describe 'is_obstructed?' do


### PR DESCRIPTION
Implements the en passant move and capture for pawns as according to: https://en.wikipedia.org/wiki/Chess#En_passant

"When a pawn advances two squares from its starting position and there is an opponent's pawn on an adjacent file next to its destination square, then the opponent's pawn can capture it en passant (in passing), and move to the square the pawn passed over. However, this can only be done on the very next move, otherwise the right to do so is forfeit."

Added fields to the game data base for the id of the last moved piece and its previous x and y position. Figured this would be more useful than a pawn-specific database field in the Piece model (since we are using STI), and this way we can show/remind users of the last move in case they missed it.
