### PR TITLE
Add wins, losses, and draws to User model

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -48,8 +48,12 @@ class GamesController < ApplicationController
   def forfeit
     if current_user.id == current_game.white_user_id
       current_game.update_attributes(game_winner: current_game.black_user_id)
+      black_user.update_attributes(user_wins: black_user.user_wins + 1)
+      white_user.update_attributes(user_losses: white_user.user_losses + 1)
     elsif current_user.id == current_game.black_user_id
       current_game.update_attributes(game_winner: current_game.white_user_id)
+      white_user.update_attributes(user_wins: white_user.user_wins + 1)
+      black_user.update_attributes(user_losses: black_user.user_losses + 1)
     end
     redirect_to game_path(current_game)
     begin
@@ -71,6 +75,8 @@ class GamesController < ApplicationController
 
   def accept_draw
     current_game.update_attributes(draw: true)
+    white_user.update_attributes(user_draws: white_user.user_draws + 1)
+    black_user.update_attributes(user_draws: black_user.user_draws + 1)
     redirect_to game_path(current_game)
     begin
       PrivatePub.publish_to("/games/#{current_game.id}", "window.location.reload();")
@@ -155,5 +161,13 @@ class GamesController < ApplicationController
     end
     flash[:alert] = @game.errors.full_messages.last
     redirect_to root_path
+  end
+
+  def black_user
+    black_user ||= User.find(@piece.game.black_user.id)
+  end
+
+  def white_user
+    white_user ||= User.find(@piece.game.white_user.id)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -164,10 +164,10 @@ class GamesController < ApplicationController
   end
 
   def black_user
-    black_user ||= User.find(@piece.game.black_user.id)
+    black_user ||= User.find(current_game.black_user.id)
   end
 
   def white_user
-    white_user ||= User.find(@piece.game.white_user.id)
+    white_user ||= User.find(current_game.white_user.id)
   end
 end

--- a/db/migrate/20151229044855_add_wins_losses_draws_to_users.rb
+++ b/db/migrate/20151229044855_add_wins_losses_draws_to_users.rb
@@ -1,0 +1,12 @@
+class AddWinsLossesDrawsToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :user_wins, :integer, default: 0
+    add_column :users, :user_losses, :integer, default: 0
+    add_column :users, :user_draws, :integer, default: 0
+  end
+  def down
+    remove_column :users, :user_wins, :integer
+    remove_column :users, :user_losses, :integer
+    remove_column :users, :user_draws, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151224080334) do
+ActiveRecord::Schema.define(version: 20151229044855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,10 @@ ActiveRecord::Schema.define(version: 20151224080334) do
     t.integer  "white_user_id"
     t.integer  "black_user_id"
     t.integer  "game_winner"
-    t.boolean  "draw",          default: false
+    t.boolean  "draw",                  default: false
+    t.integer  "last_moved_piece_id"
+    t.integer  "last_moved_prev_x_pos"
+    t.integer  "last_moved_prev_y_pos"
   end
 
   add_index "games", ["black_user_id"], name: "index_games_on_black_user_id", using: :btree
@@ -58,11 +61,15 @@ ActiveRecord::Schema.define(version: 20151224080334) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.integer  "user_wins",              default: 0
+    t.integer  "user_losses",            default: 0
+    t.integer  "user_draws",             default: 0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "games", "pieces", name: "games_last_moved_piece_fk", column: "last_moved_piece_id"
   add_foreign_key "games", "users", name: "games_black_user_id_fk", column: "black_user_id"
   add_foreign_key "games", "users", name: "games_game_winner_fk", column: "game_winner"
   add_foreign_key "games", "users", name: "games_user_turn_fk", column: "user_turn"

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -191,6 +191,10 @@ RSpec.describe GamesController, type: :controller do
       put :forfeit, id: current_game
       current_game.reload
       expect(current_game.game_winner).to eq(current_game.black_user.id)
+      black_user.reload
+      white_user.reload
+      expect(black_user.user_wins).to eq 1
+      expect(white_user.user_losses).to eq 1
     end
     it "will declare White player as the winner" do
       current_game = FactoryGirl.build(:game)
@@ -202,6 +206,10 @@ RSpec.describe GamesController, type: :controller do
       put :forfeit, id: current_game
       current_game.reload
       expect(current_game.game_winner).to eq(current_game.white_user.id)
+      black_user.reload
+      white_user.reload
+      expect(white_user.user_wins).to eq 1
+      expect(black_user.user_losses).to eq 1
     end
   end
   describe 'Draw' do
@@ -221,10 +229,15 @@ RSpec.describe GamesController, type: :controller do
         current_game.assign_attributes(user_turn: current_game.black_user_id, draw_request: current_game.white_user)
         current_game.save!
         black_user = current_game.black_user
+        white_user = current_game.white_user
         sign_in black_user
         put :accept_draw, id: current_game
         current_game.reload
         expect(current_game.draw).to eq(true)
+        black_user.reload
+        white_user.reload
+        expect(black_user.user_draws).to eq 1
+        expect(white_user.user_draws).to eq 1
       end
       it "will be declined" do
         current_game = FactoryGirl.build(:game)
@@ -254,10 +267,15 @@ RSpec.describe GamesController, type: :controller do
         current_game.assign_attributes(user_turn: current_game.black_user_id, draw_request: current_game.black_user)
         current_game.save!
         white_user = current_game.white_user
+        black_user = current_game.black_user
         sign_in white_user
         put :accept_draw, id: current_game
         current_game.reload
         expect(current_game.draw).to eq(true)
+        black_user.reload
+        white_user.reload
+        expect(black_user.user_draws).to eq 1
+        expect(white_user.user_draws).to eq 1
       end
       it "will be declined" do
         current_game = FactoryGirl.build(:game)

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -167,6 +167,32 @@ RSpec.describe PiecesController, type: :controller do
       # turn should change to loser
       expect(current_game.user_turn).to eq current_game.white_user_id
     end
+    it "will update players wins and losses when game ends in checkmate" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.black_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in black_user
+      current_game.pieces.delete_all
+      white_king = King.create(color: true, game_id: current_game.id, user_id: current_game.white_user_id, x_position: 0, y_position: 0)
+      black_king = King.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 7, y_position: 7)
+      black_queen = Queen.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 6, y_position: 1)
+      black_pawn = Pawn.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 2, y_position: 2)
+      expect(current_game.game_winner).to be_nil
+      put :update, id: black_queen.id, x: 1, y: 1
+      current_game.reload
+      expect(current_game.game_winner).to eq current_game.black_user_id
+      expect(flash[:alert]).to eq("Checkmate! You win!")
+      expect(response).to redirect_to(current_game)
+      # turn should change to loser
+      expect(current_game.user_turn).to eq current_game.white_user_id
+      black_user.reload
+      white_user.reload
+      # may need to change this if testing methodology changes
+      expect(black_user.user_wins).to eq 1
+      expect(white_user.user_losses).to eq 1
+    end
     it "will set stalement when opposing player cannot move without going into check" do
       current_game = FactoryGirl.build(:game)
       current_game.assign_attributes(user_turn: current_game.black_user_id)
@@ -187,6 +213,29 @@ RSpec.describe PiecesController, type: :controller do
       expect(response).to redirect_to(current_game)
       # turn should change to next player
       expect(current_game.user_turn).to eq current_game.white_user_id
+    end
+    it "will increment black and white user draws when game is a stalemate" do
+      current_game = FactoryGirl.build(:game)
+      current_game.assign_attributes(user_turn: current_game.black_user_id)
+      current_game.save!
+      black_user = current_game.black_user
+      white_user = current_game.white_user
+      sign_in black_user
+      current_game.pieces.delete_all
+      white_king = King.create(color: true, game_id: current_game.id, user_id: current_game.white_user_id, x_position: 5, y_position: 0)
+      black_pawn = Pawn.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 5, y_position: 1)
+      black_king = King.create(color: false, game_id: current_game.id, user_id: current_game.black_user_id, x_position: 5, y_position: 3)
+
+      expect(current_game.draw?).to eq false
+      put :update, id: black_king.id, x: 5, y: 2
+      current_game.reload
+      expect(current_game.draw?).to eq true
+      expect(flash[:alert]).to eq("White is in stalemate! Game is a draw.")
+      black_user.reload
+      white_user.reload
+      # may need to change this if testing methodology changes
+      expect(black_user.user_draws).to eq 1
+      expect(white_user.user_draws).to eq 1
     end
   end
 


### PR DESCRIPTION
Add wins, losses, and draws field to user model. Update wins and losses on checkmate, and draws on stalemate. This way if anything happens to the Games table (say games need to be deleted/archived to save space), we can still keep track of W/L/D.
