### PR TITLE
Jg/javascript for moves

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'devise'
 # Implement foreign keys
 gem 'foreigner'
 
+# JQuery UI for drag and drop features
+gem 'jquery-ui-rails'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -194,6 +196,7 @@ DEPENDENCIES
   foreigner
   jbuilder (~> 1.2)
   jquery-rails
+  jquery-ui-rails
   pg
   pry-byebug
   rails (= 4.0.1)
@@ -204,3 +207,6 @@ DEPENDENCIES
   sdoc
   simple_form
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery-ui
 //= require bootstrap-sprockets
 //= require jquery_ujs
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require jquery-ui
  */
 
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/games.css.scss
+++ b/app/assets/stylesheets/games.css.scss
@@ -6,7 +6,6 @@
   background-color: grey;
   border: 1px solid black;
   margin: 0 auto;
-  padding-top: 40px;
   width: auto;
   border-collapse: collapse;
 

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -1,7 +1,7 @@
 td a {
-  display:block;
-  width:100%;
-  height: 100%;
+  display: block;
+  width: 100%;
+  height: 85%;
 }
 
 .navbar {

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,5 @@
 class GamesController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :update]
+  before_action :authenticate_user!, only: [:create, :update, :move]
 
   def new
     @game = Game.new

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -48,9 +48,9 @@ class GamesController < ApplicationController
 
   def place_piece_td(row, column)
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-'#{column}' "
+    board_square = "<td class='x-position-#{column}' "
     board_square += "piece-id-data='#{piece_id(find_piece)}' "
-    board_square += "piece-type-data='#{piece_type(find_piece)}''>"
+    board_square += "piece-type-data='#{piece_type(find_piece)}'>"
     unless find_piece.nil?
       image = ActionController::Base.helpers.image_tag find_piece
                                     .image_name, size: '40x45',

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -35,11 +35,9 @@ class GamesController < ApplicationController
 
   def move
     respond_to do |format|
-      format.json { redirect_to piece_path(params[:piece_id])}
-      format.html { redirect_to game_path(current_game)}
+      format.json { redirect_to piece_path(params[:piece_id]) }
+      format.html { redirect_to game_path(current_game) }
     end
-    #redirect_to pieces_path(params[:piece_id])
-    #render "pieces/#{params[:piece_id]}/update"
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -33,6 +33,15 @@ class GamesController < ApplicationController
     handle_update_errors
   end
 
+  def move
+    respond_to do |format|
+      format.json { redirect_to piece_path(params[:piece_id])}
+      format.html { redirect_to game_path(current_game)}
+    end
+    #redirect_to pieces_path(params[:piece_id])
+    #render "pieces/#{params[:piece_id]}/update"
+  end
+
   private
 
   helper_method :current_game, :place_piece_td
@@ -52,6 +61,7 @@ class GamesController < ApplicationController
     if find_piece.nil?
       board_square += ">"
     else
+      #board_square += " data-piece-url= #{piece_path(find_piece)}"
       board_square += " piece-id-data='#{piece_id(find_piece)}' "
       board_square += "piece-type-data='#{piece_type(find_piece)}'>"
       image = ActionController::Base.helpers.image_tag find_piece

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -48,10 +48,12 @@ class GamesController < ApplicationController
 
   def place_piece_td(row, column)
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-#{column}' "
-    board_square += "piece-id-data='#{piece_id(find_piece)}' "
-    board_square += "piece-type-data='#{piece_type(find_piece)}'>"
-    unless find_piece.nil?
+    board_square = "<td class='x-position-#{column}'"
+    if find_piece.nil?
+      board_square += ">"
+    else
+      board_square += " piece-id-data='#{piece_id(find_piece)}' "
+      board_square += "piece-type-data='#{piece_type(find_piece)}'>"
       image = ActionController::Base.helpers.image_tag find_piece
                                     .image_name, size: '40x45',
                                    class: 'img-responsive center-block'

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -57,13 +57,12 @@ class GamesController < ApplicationController
 
   def place_piece_td(row, column)
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-#{column}'"
+    board_square = "<td data-x-position='#{column}'"
     if find_piece.nil?
       board_square += ">"
     else
-      #board_square += " data-piece-url= #{piece_path(find_piece)}"
-      board_square += " piece-id-data='#{piece_id(find_piece)}' "
-      board_square += "piece-type-data='#{piece_type(find_piece)}'>"
+      board_square += " data-piece-id='#{piece_id(find_piece)}' "
+      board_square += "data-piece-type='#{piece_type(find_piece)}'>"
       image = ActionController::Base.helpers.image_tag find_piece
               .image_name, size: '40x45',
                            class: 'img-responsive center-block'

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,6 @@
 class GamesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :update, :move]
-  
+
   def new
     @game = Game.new
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -28,27 +28,30 @@ class GamesController < ApplicationController
   end
 
   def update
-    @game = Game.find(params[:id])
-    if @game.player_missing?
-      update_player
-      if @game.errors.empty?
-        flash[:notice] = "Joined the game!"
-        redirect_to game_path(@game)
-        begin
-          PrivatePub.publish_to("/games/#{@game.id}", "window.location.reload();")
-        rescue Errno::ECONNREFUSED
-          flash.now[:alert] = "Pushing to Faye Failed"
+    respond_to do |format| 
+      format.html {
+        @game = Game.find(params[:id])
+        if @game.player_missing?
+          update_player
+          if @game.errors.empty?
+            flash[:notice] = "Joined the game!"
+            redirect_to game_path(@game)
+            begin
+              PrivatePub.publish_to("/games/#{@game.id}", "window.location.reload();")
+            rescue Errno::ECONNREFUSED
+              flash.now[:alert] = "Pushing to Faye Failed"
+            end
+            return
+          end
         end
-        return
-      end
+        handle_update_errors }
     end
-    handle_update_errors
   end
 
   def move
     respond_to do |format|
       format.json { redirect_to piece_path(params[:piece_id]) }
-      format.html { redirect_to game_path(current_game) }
+      format.html { redirect_to piece_path(params[:piece_id]) }
     end
   end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -49,8 +49,8 @@ class GamesController < ApplicationController
     respond_to do |format|
       format.json { redirect_to piece_path(params[:piece_id]) }
       format.html { redirect_to game_path(current_game) }
+    end
   end
-end
 
   def forfeit
     if current_user.id == current_game.white_user_id

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -30,14 +30,15 @@ class PiecesController < ApplicationController
   def show_piece_td(row, column)
     @current_game = current_game
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-#{column}' "
-    board_square += "piece-id-data='#{piece_id(find_piece)}' "
-    board_square += "piece-type-data='#{piece_type(find_piece)}'>"
+    board_square = "<td class='x-position-#{column}'"
     url = piece_path(Piece.find(params[:id]))
     url += "?x=#{column}&y=#{row}"
     if find_piece.nil?
+      board_square += ">"
       board_square += ActionController::Base.helpers.link_to '', url, method: :put
     else
+      board_square += " piece-id-data='#{piece_id(find_piece)}' "
+      board_square += "piece-type-data='#{piece_type(find_piece)}'>"
       image = ActionController::Base.helpers.image_tag find_piece
                       .image_name, size: '40x45',
                                    class: 'img-responsive center-block'

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -30,9 +30,9 @@ class PiecesController < ApplicationController
   def show_piece_td(row, column)
     @current_game = current_game
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-'#{column}' "
+    board_square = "<td class='x-position-#{column}' "
     board_square += "piece-id-data='#{piece_id(find_piece)}' "
-    board_square += "piece-type-data='#{piece_type(find_piece)}''>"
+    board_square += "piece-type-data='#{piece_type(find_piece)}'>"
     url = piece_path(Piece.find(params[:id]))
     url += "?x=#{column}&y=#{row}"
     if find_piece.nil?

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -40,6 +40,7 @@ class PiecesController < ApplicationController
     respond_to do |format|
       format.json { render :json => @piece.to_json }
       format.html { redirect_to game_path(@piece.game) }
+    end
     begin
       PrivatePub.publish_to("/games/#{@piece.game.id}", "window.location.reload();")
     rescue Errno::ECONNREFUSED
@@ -116,7 +117,10 @@ class PiecesController < ApplicationController
     # run before any pieces controller action
     if current_user.id != current_game.user_turn
       flash[:alert] = "Not your turn!"
-      redirect_to game_path(current_game)
+      respond_to do |format|
+        format.html { redirect_to game_path(current_game)}
+        format.json { render json: @piece.errors, status: "Not your turn!"}
+      end
     end
   end
 
@@ -124,8 +128,10 @@ class PiecesController < ApplicationController
     # run before any pieces controller action
     if @piece.user.nil? || current_user.id != @piece.user.id
       flash[:alert] = "Not your piece!"
-      redirect_to game_path(current_game)
+      respond_to do |format|
+        format.html { redirect_to game_path(current_game)}
+        format.json { render json: @piece.errors, status: "Not your piece!"}
+      end
     end
   end
-
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -49,6 +49,10 @@ class PiecesController < ApplicationController
       # end turn
       @piece.game.finish_turn(@piece.user) # otherwise turn goes to other player
     end
+    respond_to do |format|
+      format.json { render :json => @piece.to_json }
+      format.html { redirect_to game_path(@piece.game) }
+    end
     redirect_to game_path(@piece.game)
     begin
       PrivatePub.publish_to("/games/#{@piece.game.id}", "window.location.reload();")

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -28,7 +28,10 @@ class PiecesController < ApplicationController
       $old_y = @piece.y_position
       $intended_x = new_x
       $intended_y = new_y
-      redirect_to promotion_choice_piece_path(@piece) and return
+      respond_to do |format|
+        format.json { redirect_to promotion_choice_piece_path(@piece) and return }
+        format.html { redirect_to promotion_choice_piece_path(@piece) and return }
+      end
     end
     if @piece.move_to!(new_x, new_y)
       opponent_king = @piece.game.kings.where.not(color: @piece.color).first

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,8 +8,17 @@ class PiecesController < ApplicationController
 
   def update
     @piece = Piece.find(params[:id])
+    #if request.xhr?
+    #  @piece.update_attributes(x_position)
+    #else
     @piece.update_attributes(x_position: params[:x], y_position: params[:y])
-    redirect_to game_path(@piece.game)
+    #end
+    
+    respond_to do |format|
+      format.json { render :json => @piece.to_json }
+      format.html { redirect_to game_path(@piece.game) }
+    end
+    
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -34,7 +34,7 @@ class PiecesController < ApplicationController
   def show_piece_td(row, column)
     @current_game = current_game
     find_piece = board_display_piece_query(row, column)
-    board_square = "<td class='x-position-#{column}'"
+    board_square = "<td data-x-position='#{column}'"
     url = piece_path(Piece.find(params[:id]))
     url += "?x=#{column}&y=#{row}"
     if find_piece.nil?
@@ -42,8 +42,8 @@ class PiecesController < ApplicationController
       board_square += ActionController::Base.helpers.link_to '',
                                                              url, method: :put
     else
-      board_square += " piece-id-data='#{piece_id(find_piece)}' "
-      board_square += "piece-type-data='#{piece_type(find_piece)}'>"
+      board_square += " data-piece-id='#{piece_id(find_piece)}' "
+      board_square += "data-piece-type='#{piece_type(find_piece)}'>"
       image = ActionController::Base.helpers.image_tag find_piece
               .image_name, size: '40x45',
                            class: 'img-responsive center-block'

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -55,6 +55,7 @@ class PiecesController < ApplicationController
     else
       respond_to do |format|
         format.json { render json: { errors: @piece.errors.full_messages }, :status => 400 }
+        format.html { redirect_to game_path(@piece.game) }
       end
       return
     end
@@ -103,7 +104,6 @@ class PiecesController < ApplicationController
       dest_piece.update_attributes(x_position: $intended_x, y_position: $intended_y, captured: false) # reset
     end
     @piece.update_attributes(x_position: $old_x, y_position: $old_y) # reset
-    #binding.pry
   end
 
   def promote_pawn

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,7 +13,6 @@ class PiecesController < ApplicationController
       format.json { render :json => @piece.to_json }
       format.html { redirect_to game_path(@piece.game) }
     end
-    
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,12 +8,7 @@ class PiecesController < ApplicationController
 
   def update
     @piece = Piece.find(params[:id])
-    #if request.xhr?
-    #  @piece.update_attributes(x_position)
-    #else
     @piece.update_attributes(x_position: params[:x], y_position: params[:y])
-    #end
-    
     respond_to do |format|
       format.json { render :json => @piece.to_json }
       format.html { redirect_to game_path(@piece.game) }

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -53,7 +53,6 @@ class PiecesController < ApplicationController
       format.json { render :json => @piece.to_json }
       format.html { redirect_to game_path(@piece.game) }
     end
-    redirect_to game_path(@piece.game)
     begin
       PrivatePub.publish_to("/games/#{@piece.game.id}", "window.location.reload();")
       PrivatePub.publish_to("/", "window.location.reload();")

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -20,21 +20,45 @@ $(document).ready(function () {
   $("td").droppable({
       drop: function(event, ui) {
         snapToMiddle(ui.draggable,$(this));
+        var old_x_pos = ui.draggable.parent().parent().data('x-position');
+        var old_y_pos = ui.draggable.parent().parent().parent().data('y-position');
         var x_pos = $(this).data('x-position');
         var y_pos = $(this).parent().data('y-position');
         var current_piece_id = ui.draggable.parent().parent().data('piece-id');
-        $.ajax({
-            url: "<%=current_game.id%>/move",
-            type: 'PUT',
-            dataType: 'json',
-            data: { piece_id: current_piece_id, x: x_pos, y: y_pos},
-              success: function () {
-                location.reload(true); //refreshes page from server after move
-              },
-              error: function () {
-                location.reload(true); //refreshes page from server after failed move
-              }
-        });
+        var image_name = ui.draggable.attr("alt");
+        var color = image_name.split(' ')[0];
+        var piece_type = image_name.split(' ')[1];
+        if (!((old_x_pos == x_pos)&&(old_y_pos == y_pos))) {  //prevent invalid move from popping up if you don't actually move
+          if ((piece_type === "pawn") && ((color === "Black" && y_pos === 0) || (color === "White" && y_pos === 7))) {
+            $.ajax({
+                url: "<%=current_game.id%>/move",
+                type: 'PUT',
+                dataType: 'html',
+                data: { piece_id: current_piece_id, x: x_pos, y: y_pos },
+                  success: function () {
+                    // goes to promotion url if pawn moving to last row
+                    window.location.replace("/pieces/" + current_piece_id + "/promotion_choice");
+                  },
+                  error: function () {
+                    location.reload(true); //refreshes page from server after failed move
+                  }
+            });
+          }
+          else {
+            $.ajax({
+                url: "<%=current_game.id%>/move",
+                type: 'PUT',
+                dataType: 'json',
+                data: { piece_id: current_piece_id, x: x_pos, y: y_pos},
+                  success: function () {
+                    location.reload(true); //refreshes page from server after move
+                  },
+                  error: function () {
+                    location.reload(true); //refreshes page from server after failed move
+                  }
+            });
+          }
+        }
       }
   });
 });

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,5 @@
 <script type="text/javascript">
 $(document).ready(function () {
-  //var piece_number;
   $("[data-piece-id]").children("[href]").children('img').draggable({
     containment: ".chessboard",
     create: function(){$(this).data('position',$(this).position())},
@@ -8,10 +7,6 @@ $(document).ready(function () {
     cursor:'move',
     start: function( event, ui ) {
       $(this).stop(true,true);
-      //console.log($(this).parent().parent().data('piece-id'));
-      //piece_number = $(this).parent().data('piece-id');
-      //piece_url = $(this).parent().attr("href");
-
     }
   });
 
@@ -24,12 +19,9 @@ $(document).ready(function () {
   $("td").droppable({
       drop: function(event, ui) {
         snapToMiddle(ui.draggable,$(this));
-        console.log($(this).data('x-position'));
-        console.log($(this).parent().data('y-position'));
-        console.log(ui.draggable.parent().parent().data('piece-id'));
-        var x_pos = $(this).data('x-position');//$(this).attr("class").match(/\d+/)[0];
-        var y_pos = $(this).parent().data('y-position');//$(this).parent().attr("class").match(/\d+/)[0];
-        var current_piece_id = ui.draggable.parent().parent().data('piece-id');//piece_url.match(/\d+/)[0];
+        var x_pos = $(this).data('x-position');
+        var y_pos = $(this).parent().data('y-position');
+        var current_piece_id = ui.draggable.parent().parent().data('piece-id');
         $.ajax({
             url: "<%=current_game.id%>/move",
             type: 'PUT',

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,14 +1,16 @@
 <script type="text/javascript">
 $(document).ready(function () {
-  var piece_url;
-  $("[piece-id-data]").children("[href]").children('img').draggable({
+  //var piece_number;
+  $("[data-piece-id]").children("[href]").children('img').draggable({
     containment: ".chessboard",
     create: function(){$(this).data('position',$(this).position())},
     cursorAt:{left:15},
     cursor:'move',
     start: function( event, ui ) {
-      $(this).stop(true,true)
-      piece_url = $(this).parent().attr("href");
+      $(this).stop(true,true);
+      //console.log($(this).parent().parent().data('piece-id'));
+      //piece_number = $(this).parent().data('piece-id');
+      //piece_url = $(this).parent().attr("href");
 
     }
   });
@@ -22,9 +24,12 @@ $(document).ready(function () {
   $("td").droppable({
       drop: function(event, ui) {
         snapToMiddle(ui.draggable,$(this));
-        var x_pos = $(this).attr("class").match(/\d+/)[0];
-        var y_pos = $(this).parent().attr("class").match(/\d+/)[0];
-        var current_piece_id = piece_url.match(/\d+/)[0];
+        console.log($(this).data('x-position'));
+        console.log($(this).parent().data('y-position'));
+        console.log(ui.draggable.parent().parent().data('piece-id'));
+        var x_pos = $(this).data('x-position');//$(this).attr("class").match(/\d+/)[0];
+        var y_pos = $(this).parent().data('y-position');//$(this).parent().attr("class").match(/\d+/)[0];
+        var current_piece_id = ui.draggable.parent().parent().data('piece-id');//piece_url.match(/\d+/)[0];
         $.ajax({
             url: "<%=current_game.id%>/move",
             type: 'PUT',
@@ -51,7 +56,7 @@ $(document).ready(function () {
 </div>
 <table class="chessboard">
   <% (0..7).to_a.reverse.each do |row| %>
-    <tr class="y-position-<%= row %>" >
+    <tr data-y-position="<%= row %>">
       <% (0..7).each do |column| %>
         <%= place_piece_td(row, column).html_safe %>
       <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,3 +1,4 @@
+<% if current_game && current_user && ((current_user.id == current_game.white_user_id) || (current_user.id == current_game.black_user_id)) %>
 <script type="text/javascript">
 $(document).ready(function () {
   $("[data-piece-id]").children("[href]").children('img').draggable({
@@ -26,15 +27,19 @@ $(document).ready(function () {
             url: "<%=current_game.id%>/move",
             type: 'PUT',
             dataType: 'json',
-            data: { piece_id: current_piece_id, x: x_pos, y: y_pos}
-        })
-        .done (function() {
-          location.reload(true); //refreshes page from server after move
-      });
+            data: { piece_id: current_piece_id, x: x_pos, y: y_pos},
+              success: function () {
+                location.reload(true); //refreshes page from server after move
+              },
+              error: function () {
+                location.reload(true); //refreshes page from server after failed move
+              }
+        });
       }
   });
 });
 </script>
+<% end %>
 <!-- games.show page -->
 <% if current_game %>
   <br />
@@ -104,7 +109,7 @@ $(document).ready(function () {
   <div class="col-xs-12 col-sm-6">
     <table class="chessboard">
       <% (0..7).to_a.reverse.each do |row| %>
-        <tr class="y-position-<%= row %>" >
+        <tr data-y-position="<%= row %>" >
           <% (0..7).each do |column| %>
             <%= place_piece_td(row, column).html_safe %>
           <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,6 +2,7 @@
 <script type="text/javascript">
 $(document).ready(function () {
   $("[data-piece-id]").children("[href]").children('img').draggable({
+    stack: "div",
     containment: ".chessboard",
     create: function(){$(this).data('position',$(this).position())},
     cursorAt:{left:15},

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -127,7 +127,7 @@ $(document).ready(function () {
     <table class="chessboard">
       <% if current_user && current_user.id == current_game.black_user_id %>
         <% (0..7).each do |row| %>
-            <tr class="y-position-<%= row %>" >
+            <tr data-y-position="<%= row %>" >
               <% (0..7).to_a.reverse.each do |column| %>
                 <%= place_piece_td(row, column).html_safe %>
               <% end %>
@@ -135,7 +135,7 @@ $(document).ready(function () {
           <% end %>
       <% else %>
         <% (0..7).to_a.reverse.each do |row| %>
-            <tr class="y-position-<%= row %>" >
+            <tr data-y-position="<%= row %>" >
               <% (0..7).each do |column| %>
                 <%= place_piece_td(row, column).html_safe %>
               <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -3,54 +3,42 @@ $(document).ready(function () {
   var piece_url;
   $("[piece-id-data]").children("[href]").children('img').draggable({
     containment: ".chessboard",
-    //snap : "td",
+    create: function(){$(this).data('position',$(this).position())},
+    cursorAt:{left:15},
+    cursor:'move',
     start: function( event, ui ) {
-      piece_url = $(this).parent().attr("href");//.parent();//.attr("piece-id-data");
-      //console.log(piece_url);
-      //$.post(piece_url)
+      $(this).stop(true,true)
+      piece_url = $(this).parent().attr("href");
+
     }
   });
+
+  function snapToMiddle(dragger, target){
+      var topMove = target.position().top - dragger.data('position').top + (target.outerHeight(true) - dragger.outerHeight(true)) / 2;
+      var leftMove= target.position().left - dragger.data('position').left + (target.outerWidth(true) - dragger.outerWidth(true)) / 2;
+      dragger.animate({top:topMove,left:leftMove},{duration:600,easing:'easeOutBack'});
+  }
   
   $("td").droppable({
-      //var x_pos = $(this);
-      //var classList = document.getElementById('divId').className.split(/\s+/);
-      //console.log(classList);
-      //var final_url = $(this);//.children("[href]").attr("href");
-     // x_val = ui.droppable.parent("[href]").parent("[piece-id-data]").attr("piece-id-data")
-      //y_val = ui.droppable.parent("[href]").parent("[piece-id-data]").attr("piece-id-data")
-      //var square_url = ($this).children("[href]").attr('href');
-      //console.log(final_url);
       drop: function(event, ui) {
+        snapToMiddle(ui.draggable,$(this));
         var x_pos = $(this).attr("class").match(/\d+/)[0];
         var y_pos = $(this).parent().attr("class").match(/\d+/)[0];
-        var piece_id = piece_url.match(/\d+/)[0];
-        var update_url = piece_url + "?x=" + x_pos + "&y=" + y_pos;
-        var coords = { x: x_pos,
-                       y: y_pos,
-                       id: piece_id};
-        console.log(coords);
-        var blah = ui.draggable.parent().attr("href");
-        console.log(blah);
-          //var id = ui.draggable.find("img").attr("id");
-          //$("td").text(id);
+        var current_piece_id = piece_url.match(/\d+/)[0];
         $.ajax({
-            url: "<%= piece_path() %>"+"?x="+x_pos+"&y="+y_pos,
-            type: 'PUT'//,
-            //data: JSON.stringify(coords),
-            //contentType: 'application/json'
-            //success: callback || $.noop,
-            //error: errorCallback || $.noop
-        });
+            url: "<%=current_game.id%>/move",
+            type: 'PUT',
+            dataType: 'json',
+            data: { piece_id: current_piece_id, x: x_pos, y: y_pos}
+        })
+        .done (function() {
+          location.reload(true); //refreshes page from server after move
+      });
       }
-      //console.log(square_url);
-     // Console.log(x_val);
-      //Console.log(y_val);
-      //drop: function(ev, ui) {
-       //   $.post('/pieces/'+piece_id+'?x=' + x_val + '&y=' + y_val);
-      //}
   });
 });
 </script>
+
 <% if current_game %>
 <br />
 <br />

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,3 +1,56 @@
+<script type="text/javascript">
+$(document).ready(function () {
+  var piece_url;
+  $("[piece-id-data]").children("[href]").children('img').draggable({
+    containment: ".chessboard",
+    //snap : "td",
+    start: function( event, ui ) {
+      piece_url = $(this).parent().attr("href");//.parent();//.attr("piece-id-data");
+      //console.log(piece_url);
+      //$.post(piece_url)
+    }
+  });
+  
+  $("td").droppable({
+      //var x_pos = $(this);
+      //var classList = document.getElementById('divId').className.split(/\s+/);
+      //console.log(classList);
+      //var final_url = $(this);//.children("[href]").attr("href");
+     // x_val = ui.droppable.parent("[href]").parent("[piece-id-data]").attr("piece-id-data")
+      //y_val = ui.droppable.parent("[href]").parent("[piece-id-data]").attr("piece-id-data")
+      //var square_url = ($this).children("[href]").attr('href');
+      //console.log(final_url);
+      drop: function(event, ui) {
+        var x_pos = $(this).attr("class").match(/\d+/)[0];
+        var y_pos = $(this).parent().attr("class").match(/\d+/)[0];
+        var piece_id = piece_url.match(/\d+/)[0];
+        var update_url = piece_url + "?x=" + x_pos + "&y=" + y_pos;
+        var coords = { x: x_pos,
+                       y: y_pos,
+                       id: piece_id};
+        console.log(coords);
+        var blah = ui.draggable.parent().attr("href");
+        console.log(blah);
+          //var id = ui.draggable.find("img").attr("id");
+          //$("td").text(id);
+        $.ajax({
+            url: "<%= piece_path() %>"+"?x="+x_pos+"&y="+y_pos,
+            type: 'PUT'//,
+            //data: JSON.stringify(coords),
+            //contentType: 'application/json'
+            //success: callback || $.noop,
+            //error: errorCallback || $.noop
+        });
+      }
+      //console.log(square_url);
+     // Console.log(x_val);
+      //Console.log(y_val);
+      //drop: function(ev, ui) {
+       //   $.post('/pieces/'+piece_id+'?x=' + x_val + '&y=' + y_val);
+      //}
+  });
+});
+</script>
 <% if current_game %>
 <br />
 <br />

--- a/app/views/pieces/promotion_choice.html.erb
+++ b/app/views/pieces/promotion_choice.html.erb
@@ -4,9 +4,10 @@
   <h3 class ="text-center">Promote Your Pawn</h3>
   <div class="col-md-2 col-md-offset-5">
     <%= simple_form_for @piece, :url => promote_pawn_piece_path, method: :patch do |f| %>
-      <%= f.input :piece_type, collection: @button_list, as: :radio_buttons, label: 'Promote to:', class: 'form-control' %>
+      <%= f.input :piece_type, collection: @button_list, as: :radio_buttons, label: 'Promote to:', class: 'form-control', :checked => @button_list[0] %>
       <br />
       <%= f.submit "Promote!", :class => 'btn btn-primary' %> 
+      <br />
       <br />
       <%= link_to "Cancel", game_path(@piece.game), {:class=>"btn btn-danger"} %>
       <br />

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -10,7 +10,7 @@
 </div>
 <table class="chessboard">
   <% (0..7).to_a.reverse.each do |row| %>
-    <tr class="y-position-<%= row %>" >
+    <tr data-y-position="<%= row %>">
       <% (0..7).each do |column| %>
         <%= show_piece_td(row, column).html_safe %>
       <% end %>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -81,7 +81,7 @@
     <table class="chessboard">
       <% if current_user && current_user.id == current_game.black_user_id %>
         <% (0..7).each do |row| %>
-            <tr class="y-position-<%= row %>" >
+            <tr data-y-position="<%= row %>" >
               <% (0..7).to_a.reverse.each do |column| %>
                 <%= show_piece_td(row, column).html_safe %>
               <% end %>
@@ -89,7 +89,7 @@
           <% end %>
       <% else %>
         <% (0..7).to_a.reverse.each do |row| %>
-            <tr class="y-position-<%= row %>" >
+            <tr data-y-position="<%= row %>" >
               <% (0..7).each do |column| %>
                 <%= show_piece_td(row, column).html_safe %>
               <% end %>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -77,7 +77,7 @@
   <div class="col-xs-12 col-sm-6">
     <table class="chessboard">
       <% (0..7).to_a.reverse.each do |row| %>
-        <tr class="y-position-<%= row %>" >
+        <tr data-y-position="<%= row %>" >
           <% (0..7).each do |column| %>
             <%= show_piece_td(row, column).html_safe %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 FallGambit::Application.routes.draw do
   
   devise_for :users
-  resources :games, :only => [:new, :create, :show, :update]
+  put "games/:id/move", to: "games#move"
+  resources :games, :only => [:new, :create, :show, :update] #do
+    #member do
+      #put :move
+    #end
+ # end
   resources :pieces, :only => [:show, :update]
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ FallGambit::Application.routes.draw do
   resources :pieces do
     member do
       get 'promotion_choice', :action => :promotion_choice
+      put 'promotion_choice', :action => :promotion_choice
       patch 'promote_pawn', :action => :promote_pawn
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,7 @@ FallGambit::Application.routes.draw do
   
   devise_for :users
   put "games/:id/move", to: "games#move"
-  resources :games, :only => [:new, :create, :show, :update] #do
-    #member do
-      #put :move
-    #end
- # end
+  resources :games, :only => [:new, :create, :show, :update]
   resources :pieces, :only => [:show, :update]
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -141,4 +141,43 @@ RSpec.describe GamesController, type: :controller do
       end
     end
   end
+
+  describe 'PATCH #move' do
+    context 'with logged in user' do
+      login_user
+      let(:black_player) { create(:user) }
+      let(:game_to_update) do
+        Game.create(game_name: "Test",
+                    black_user_id: black_player.id)
+        context 'with an AJAX request' do
+          it 'redirects to pieces controller' do
+            xhr :put, :move, id: game_to_update.id, piece_id: 1, x: 3, y: 3
+            expect(response).to redirect_to(piece_path(piece_id))
+          end
+        end
+        context 'with an HTML request' do
+          it 'redirects to game page' do
+            put :move, id: game_to_update.id, piece_id: 1, x: 3, y: 3
+            expect(response).to redirect_to(game_to_update)
+          end
+        end
+      end
+    end
+    context 'without being logged in' do
+      context 'with an AJAX request' do
+        it 'returns unauthorized status code' do
+          game_to_update = create(:game)
+          xhr :put, :move, id: game_to_update.id, piece_id: 1, x: 3, y: 3
+          expect(response.status).to eq 401
+        end
+      end
+      context 'with an HTML request' do
+        it 'redirects to sign-in page' do
+          game_to_update = create(:game)
+          put :move, id: game_to_update.id, piece_id: 1, x: 3, y: 3
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -203,10 +203,10 @@ RSpec.describe GamesController, type: :controller do
     end
     context 'without being logged in' do
       context 'with an AJAX request' do
-        it 'returns unauthorized status code' do
+        it 'redirects to sign-in page' do
           game_to_update = create(:game)
           xhr :put, :move, id: game_to_update.id, piece_id: 1, x: 3, y: 3
-          expect(response.status).to eq 401
+          expect(response).to redirect_to(new_user_session_path)
         end
       end
       context 'with an HTML request' do


### PR DESCRIPTION
Implemented a jQuery solution using draggable and droppable so we can drag a piece on the board for movement purposes. The code can probably be refactored (and I'd like to move it to CoffeeScript later if possible), but should be good enough to push into the develop branch for now.

I created a custom 'move' controller action in the games controller which sends off the AJAX call to the pieces controller and hooks into the update action.

Flash message errors (not your turn/not your piece/invalid move, etc.) should still display correctly. Tested trying to move when it wasn't your turn as well (along with not the correct color piece).

I was able to contain the piece movement to stay on the game board, and it should refresh the board after each move to update the pieces and display flash messages. Also the drag&drop javascript should only render for the white and black player in each game (so no jQuery drag and drop for spectators, whether they are signed in or not).
