### PR TITLE
Amp/fix join game render

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,15 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  protected
+  def authenticate_user!
+    if user_signed_in?
+      super
+    else
+      redirect_to new_user_session_path, :alert => 'Must be logged in to Join or Create game!'
+      ## if you want render 404 page
+      ## render :file => File.join(Rails.root, 'public/404'), :formats => [:html], :status => 404, :layout => false
+    end
+  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -134,15 +134,12 @@ class GamesController < ApplicationController
   end
 
   def update_player
-    if current_user && @game.white_user_id.nil?
+    if @game.white_user_id.nil?
       @game.update_attributes(white_user_id: current_user.id, user_turn: current_user.id)
       @game.set_pieces_white_user_id
-    elsif current_user && @game.black_user_id.nil?
+    else
       @game.update_attributes(black_user_id: current_user.id)
       @game.set_pieces_black_user_id
-    elsif !current_user
-      flash[:alert] = "Must log in or sign in to continue!"
-      redirect_to new_user_session_path
     end
   end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -134,12 +134,15 @@ class GamesController < ApplicationController
   end
 
   def update_player
-    if @game.white_user_id.nil?
+    if current_user && @game.white_user_id.nil?
       @game.update_attributes(white_user_id: current_user.id, user_turn: current_user.id)
       @game.set_pieces_white_user_id
-    else
+    elsif current_user && @game.black_user_id.nil?
       @game.update_attributes(black_user_id: current_user.id)
       @game.set_pieces_black_user_id
+    elsif !current_user
+      flash[:alert] = "Must log in or sign in to continue!"
+      redirect_to new_user_session_path
     end
   end
 


### PR DESCRIPTION
This will redirect any anonymous users to the login screen for any actions that have an auth_user validation.  It rewrites Devise's authenticate_user! method to include the redirect and a custom flash message. Nice find @jeffgerlach.  Note: this may change current smooth redirect-to-game behavior to redirect back to root, but we can correct it in a future patch. ~AMP
